### PR TITLE
Only do composer install on existent project directory

### DIFF
--- a/src/Construct.php
+++ b/src/Construct.php
@@ -395,8 +395,10 @@ class Construct
      */
     protected function composerInstall()
     {
-        $command = 'cd ' . $this->projectLower . ' && composer install';
-        exec($command);
+        if (is_dir($this->projectLower)) {
+            $command = 'cd ' . $this->projectLower . ' && composer install';
+            exec($command);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes the `sh: line 0: cd: project: No such file or directory` messages while running the tests. 
