### PR TITLE
PHPDoc fix for project stub

### DIFF
--- a/src/stubs/Project.txt
+++ b/src/stubs/Project.txt
@@ -9,7 +9,7 @@ class {project_upper}
      * Initialize.
      *
      * @return void
-     **/
+     */
     public function __construct()
     {
 


### PR DESCRIPTION
There are also some further _faulty_ PHPDoc comments in:
- src/Commands/ConstructCommand.php
- src/Construct.php
- src/Str.php

Nitpicking off.
