### PR TITLE
Advise against using PHP notations in micro-packages.

### DIFF
--- a/src/Commands/ConstructCommand.php
+++ b/src/Commands/ConstructCommand.php
@@ -110,6 +110,12 @@ class ConstructCommand extends Command
             return false;
         }
 
+        if ($this->str->contains($projectName, 'php')) {
+            $containsPhpWarning = 'Warning: If you are about to create a micro-package "'
+                . $projectName . '" should optimally not contain a "php" notation in the project name.';
+            $output->writeln('<error>' . $containsPhpWarning . '</error>');
+        }
+
         if (!in_array($license, $this->licenses)) {
             $output->writeln('<error>Warning: "' . $license . '" is not a supported license. Using MIT.</error>');
             $license = 'MIT';

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -30,6 +30,19 @@ class Str
     }
 
     /**
+     * Check if the entered project name contains a given string.
+     *
+     * @param string $name
+     * @param string $needle
+     *
+     * @return boolean
+     */
+    public function contains($name, $needle)
+    {
+        return strstr($name, $needle) != false;
+    }
+
+    /**
      * Construct a correct project namespace name.
      *
      * @param string  $namespace        The entered namespace.

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -35,6 +35,22 @@ class ConstructTest extends PHPUnit
         $this->assertSame('Project "vendor/project" constructed.' . PHP_EOL, $commandTester->getDisplay());
     }
 
+    public function testProjectGenerationWithPhpInProjectName()
+    {
+        $this->setMocks();
+
+        $app = $this->setApplication();
+        $command = $app->find('generate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName(), 'name' => 'vendor/php-project']);
+
+        $output = 'Warning: If you are about to create a micro-package "vendor/php-project" ' .
+                  'should optimally not contain a "php" notation in the project name.' . PHP_EOL .
+                  'Project "vendor/php-project" constructed.' . PHP_EOL;
+
+        $this->assertSame($output, $commandTester->getDisplay());
+    }
+
     public function testProjectGenerationWithUnknownTestingFramework()
     {
         $this->setMocks();

--- a/tests/StrTest.php
+++ b/tests/StrTest.php
@@ -24,6 +24,15 @@ class StrTest extends PHPUnit
         $this->assertFalse($this->str->isValid('some\project'));
     }
 
+    public function testContain()
+    {
+        $this->assertTrue($this->str->contains('vendor/php-project', 'php'));
+        $this->assertTrue($this->str->contains('vendor/project-php', 'php'));
+        $this->assertFalse($this->str->contains('vendor/project', 'php'));
+        $this->assertTrue($this->str->contains('vendor/test-project-test', 'test'));
+        $this->assertTrue($this->str->contains('vendor/project-test', 'test'));
+    }
+
     public function testToLower()
     {
         $this->assertSame('jonathantorres', $this->str->toLower('JonathanTorres'));


### PR DESCRIPTION
Additional validation against using 'php' as part of the project or package name to avoid redundancy (e.g. vendorname/php-markdown). Doesn't halt construction by just displaying a relevant warning.
