### PR TITLE
Enable testing against PHP nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - hhvm
+  - nightly
   - 7
   - 5.6
   - 5.5

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -23,5 +23,5 @@ class Defaults
      *
      * @var array
      */
-    public $phpVersions = ['5.4.0', '5.5.0', '5.5.9', '5.6.0', '7.0.0'];
+    public $phpVersions = ['5.4.0', '5.5.0', '5.5.9', '5.6.0', '7.0.0', 'nightly'];
 }


### PR DESCRIPTION
As PHP 7.1 is emerging, we should start to test against it and also add it to the constructed Travis configuration.
