### PR TITLE
Improve build runtime by disabling Xdebug.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
   fast_finish: true
 
 before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - composer self-update
   - composer install -n
 


### PR DESCRIPTION
Should be re-enabled when measuring the code coverage is required. 
