### PR TITLE
Let --prefer-dist be the default.

### DIFF
--- a/src/stubs/travis.stub
+++ b/src/stubs/travis.stub
@@ -5,7 +5,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
   - composer test

--- a/tests/stubs/travis.php54.stub
+++ b/tests/stubs/travis.php54.stub
@@ -11,7 +11,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
   - composer test

--- a/tests/stubs/travis.php55.stub
+++ b/tests/stubs/travis.php55.stub
@@ -10,7 +10,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
   - composer test

--- a/tests/stubs/travis.php56.stub
+++ b/tests/stubs/travis.php56.stub
@@ -8,7 +8,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
   - composer test

--- a/tests/stubs/travis.php7.stub
+++ b/tests/stubs/travis.php7.stub
@@ -7,7 +7,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
   - composer test

--- a/tests/stubs/travis.stub
+++ b/tests/stubs/travis.stub
@@ -8,7 +8,7 @@ php:
 
 before_script:
   - travis_retry composer self-update
-  - travis_retry composer install --prefer-source --no-interaction
+  - travis_retry composer install --no-interaction
 
 script:
   - composer test


### PR DESCRIPTION
Composer's default `--prefer-dist` is faster, cacheable, and also GitHub recently removed that getting an archive is counted against the hourly API rate limit.
