### PR TITLE
Initial configuration feature implementation. Closes #86.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 * text=auto
 
+/example export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### v2.0.0 `2016-04-??`
+- `Added`
+    - User can load common option settings from a configuration file. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#86](https://github.com/jonathantorres/construct/issues/86).
+
 #### v1.9.0 `2016-04-10`
 - `Added`
     - User can optionally generate a Code of Conduct file which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4. Done by [@raphaelstolt](https://github.com/raphaelstolt).

--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ The `--code-of-conduct` option will generate a Code of Conduct file named `CONDU
 construct generate jonathantorres/logger --code-of-conduct
 ```
 
+## Use a configuration for recurring settings
+The `--config` option allows the usage of a configuration file in the `YAML` format. There are two ways to provide such a configuration file: One is to provide a specific file as an option argument, the other is to put a `.construct` configuration file in the home directory of your system. For the structure of a configuration file have a look at the [.construct](example/.construct) example file. When no configuration keys are provided for settings having a default value (i.e. `test-framework`, `license`, `php`) their default value is used.
+
+```bash
+construct generate jonathantorres/logger --config /path/to/config.yml
+```
+
+You can also use the short option `-c`.
+
+```bash
+construct generate jonathantorres/logger -c /path/to/config.yml
+```
+
+When there's a `.construct` configuration file in your home directory it will be used per default. If required it's possible to disable the usage via the `--ignore-default-config` option or the equivalent short option `-i`.
+
 ## Interactive Mode
 This mode will ask you all the required (and optional) information to generate your project.
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": "^5.4 || ^7.0",
-        "symfony/console": "^2.6 || ^3.0"
+        "symfony/console": "^2.6 || ^3.0",
+        "symfony/yaml": "^2.6 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 || ^5.0",

--- a/construct
+++ b/construct
@@ -16,8 +16,9 @@ use JonathanTorres\Construct\Helpers\Str;
 use Symfony\Component\Console\Application;
 
 $str = new Str();
-$construct = new Construct(new Filesystem(), $str);
+$filesystem = new Filesystem();
+$construct = new Construct($filesystem, $str);
 $app = new Application('Construct', '1.9.0');
-$app->add(new ConstructCommand($construct, $str));
+$app->add(new ConstructCommand($construct, $str, $filesystem));
 $app->add(new InteractiveCommand($construct, $str));
 $app->run();

--- a/example/.construct
+++ b/example/.construct
@@ -1,0 +1,14 @@
+namespace: Vendor\Project
+test-framework: phpspec
+license: MIT
+php: 5.6
+
+construct-with:
+  - git
+  - phpcs
+  - vagrant
+  - editor-config
+  - env
+  - lgtm
+  - github-templates
+  - code-of-conduct

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace JonathanTorres\Construct;
+
+use Symfony\Component\Yaml\Yaml;
+
+class Configuration
+{
+    /**
+     * Get settings derived from the configuration file.
+     *
+     * @param string                                       $configurationFile Path to the configuration file.
+     * @param string                                       $projectName       Name of the project.
+     * @param string                                       $keywords          Composer keywords.
+     * @param \JonathanTorres\Construct\Helpers\Filesystem $filesystemHelper
+     *
+     * @return \JonathanTorres\Construct\Settings
+     */
+    public static function getSettings($configurationFile, $projectName, $keywords, $filesystemHelper)
+    {
+        if (!$filesystemHelper->isFile($configurationFile)) {
+            $exceptionMessage = "Configuration file '$configurationFile' is not existent.";
+            throw new \RuntimeException($exceptionMessage);
+        }
+
+        if (!$filesystemHelper->isReadable($configurationFile)) {
+            $exceptionMessage = "Configuration file '$configurationFile' is not readable.";
+            throw new \RuntimeException($exceptionMessage);
+        }
+
+        $configuration = Yaml::parse($filesystemHelper->get($configurationFile));
+
+        if (isset($configuration['construct-with'])) {
+            $configuration['construct-with'] = array_flip($configuration['construct-with']);
+        }
+
+        return new Settings(
+            $projectName,
+            isset($configuration['test-framework']) ? $configuration['test-framework'] : (new Defaults())->testingFrameworks[0],
+            isset($configuration['license']) ? $configuration['license'] : (new Defaults())->licenses[0],
+            isset($configuration['namespace']) ? $configuration['namespace'] : null,
+            isset($configuration['construct-with']['git']) ? true : false,
+            isset($configuration['construct-with']['phpcs']) ? true : false,
+            $keywords,
+            isset($configuration['construct-with']['vagrant']) ? true : false,
+            isset($configuration['construct-with']['editor-config']) ? true : false,
+            isset($configuration['php']) ? (string) $configuration['php'] : PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+            isset($configuration['construct-with']['env']) ? true : false,
+            isset($configuration['construct-with']['lgtm']) ? true : false,
+            isset($configuration['construct-with']['github-templates']) ? true : false,
+            isset($configuration['construct-with']['code-of-conduct']) ? true : false
+        );
+    }
+}

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -28,4 +28,5 @@ class Defaults
     const TEST_FRAMEWORK = 'phpunit';
     const LICENSE = 'MIT';
     const PROJECT_NAMESPACE = 'Vendor\Project';
+    const CONFIGURATION_FILE = '.construct';
 }

--- a/src/Helpers/Filesystem.php
+++ b/src/Helpers/Filesystem.php
@@ -2,6 +2,8 @@
 
 namespace JonathanTorres\Construct\Helpers;
 
+use JonathanTorres\Construct\Defaults;
+
 class Filesystem
 {
     /**
@@ -27,6 +29,65 @@ class Filesystem
     public function isDirectory($path)
     {
         return is_dir($path);
+    }
+
+    /**
+     * Check if the path is a file.
+     *
+     * @param string $path
+     *
+     * @return boolean
+     */
+    public function isFile($path)
+    {
+        return is_file($path);
+    }
+
+    /**
+     * Check if the path is readable.
+     *
+     * @param string $path
+     *
+     * @return boolean
+     */
+    public function isReadable($path)
+    {
+        return is_readable($path);
+    }
+
+    /**
+     * Get the home directory.
+     *
+     * @return string
+     */
+    public function getHomeDirectory($os = PHP_OS)
+    {
+        if (strtoupper(substr($os, 0, 3)) !== 'WIN') {
+            return getenv('HOME');
+        }
+
+        return getenv('userprofile');
+    }
+
+    /**
+     * Get the default construct configuration file.
+     *
+     * @return string
+     */
+    public function getDefaultConfigurationFile()
+    {
+        return $this->getHomeDirectory()
+            . DIRECTORY_SEPARATOR . Defaults::CONFIGURATION_FILE;
+    }
+
+    /**
+     * Determine if system has a default configuration file.
+     *
+     * @return boolean boolean
+     */
+    public function hasDefaultConfigurationFile()
+    {
+        return $this->isFile($this->getDefaultConfigurationFile());
     }
 
     /**

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -6,6 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 use JonathanTorres\Construct\Commands\ConstructCommand;
 use JonathanTorres\Construct\Construct;
 use JonathanTorres\Construct\Helpers\Str;
+use JonathanTorres\Construct\Helpers\Filesystem as FilesystemHelper;
 use Mockery;
 use PHPUnit_Framework_TestCase as PHPUnit;
 use Symfony\Component\Console\Application;
@@ -331,6 +332,29 @@ class ConstructCommandTest extends PHPUnit
         $this->assertSame('Project "vendor/project" constructed.' . PHP_EOL, $commandTester->getDisplay());
     }
 
+    public function testProjectGenerationFromConfiguration()
+    {
+        $this->setMocks(3, 3, 10);
+        $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
+
+        $app = $this->setApplication();
+        $command = $app->find('generate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'name' => 'vendor/project-from-config',
+            '--config' => dirname(__DIR__) . '/stubs/config/complete.stub'
+        ]);
+
+        $expectedCommandDisplay = 'Initialized git repo in "project-from-config".' . PHP_EOL
+            . 'Project "vendor/project-from-config" constructed.' . PHP_EOL;
+
+        $this->assertSame(
+            $expectedCommandDisplay,
+            $commandTester->getDisplay()
+        );
+    }
+
     /**
      * @group integration
      */
@@ -352,7 +376,7 @@ class ConstructCommandTest extends PHPUnit
     {
         $app = new Application();
         $construct = new Construct($this->filesystem, new Str());
-        $app->add(new ConstructCommand($construct, new Str()));
+        $app->add(new ConstructCommand($construct, new Str(), new FilesystemHelper()));
 
         return $app;
     }

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace JonathanTorres\Construct\Tests;
+
+use JonathanTorres\Construct\Configuration;
+use JonathanTorres\Construct\Defaults;
+use JonathanTorres\Construct\Settings;
+use JonathanTorres\Construct\Helpers\Filesystem;
+use PHPUnit_Framework_TestCase as PHPUnit;
+
+class ConfigurationTest extends PHPUnit
+{
+    public function testExceptionIsRaisedOnNonExistentFile()
+    {
+        $this->setExpectedException('RuntimeException');
+        Configuration::getSettings(
+            'non-existent-file.txt',
+            'example-project',
+            'composer,keywords',
+            new Filesystem
+        );
+    }
+
+    public function testCompleteConfigIsTransformedIntoSettings()
+    {
+        $settings = Configuration::getSettings(
+            __DIR__ . '/stubs/config/complete.stub',
+            'example-project',
+            'composer,keywords',
+            new Filesystem
+        );
+
+        $this->assertInstanceOf(
+            'JonathanTorres\Construct\Settings',
+            $settings
+        );
+
+        $expectedSettings = new Settings(
+            'example-project',
+            'phpspec',
+            'MIT',
+            'Vendor\Project',
+            true,
+            true,
+            'composer,keywords',
+            true,
+            true,
+            '5.6',
+            true,
+            true,
+            true,
+            true
+        );
+
+        $this->assertEquals(
+            $expectedSettings,
+            $settings,
+            "Configuration wasn't transformed into expected Settings object."
+        );
+    }
+
+    public function testDefaultsAreUsedWhenNotConfigured()
+    {
+        $settings = Configuration::getSettings(
+            __DIR__ . '/stubs/config/php+testframework+licenceless.stub',
+            'example-project',
+            'composer,keywords',
+            new Filesystem
+        );
+
+        $this->assertSame(
+            PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
+            $settings->getPhpVersion()
+        );
+        $this->assertSame(
+            (new Defaults())->testingFrameworks[0],
+            $settings->getTestingFramework()
+        );
+        $this->assertSame(
+            (new Defaults())->licenses[0],
+            $settings->getLicense()
+        );
+    }
+}

--- a/tests/Helpers/FilesystemTest.php
+++ b/tests/Helpers/FilesystemTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace JonathanTorres\Construct\Tests\Helpers;
+
+use JonathanTorres\Construct\Defaults;
+use JonathanTorres\Construct\Helpers\Filesystem;
+use JonathanTorres\Construct\Helpers\Str;
+use PHPUnit_Framework_TestCase as PHPUnit;
+
+class FilesystemTest extends PHPUnit
+{
+    protected $filesystem;
+    protected $str;
+
+    protected function setUp()
+    {
+        $this->str = new Str();
+        $this->filesystem = new Filesystem();
+    }
+
+    public function testGetHomeDirectory()
+    {
+        if ($this->str->isWindows()) {
+            $this->assertEquals(
+                getenv('userprofile'),
+                $this->filesystem->getHomeDirectory()
+            );
+        } else {
+            $this->assertEquals(
+                getenv('HOME'),
+                $this->filesystem->getHomeDirectory()
+            );
+            putenv('userprofile=abc');
+            $this->assertEquals(
+                getenv('userprofile'),
+                $this->filesystem->getHomeDirectory('WIN')
+            );
+        }
+    }
+
+    public function testGetDefaultConfigurationFile()
+    {
+        if ($this->str->isWindows()) {
+            $this->assertEquals(
+                getenv('userprofile') . DIRECTORY_SEPARATOR . Defaults::CONFIGURATION_FILE,
+                $this->filesystem->getDefaultConfigurationFile()
+            );
+        } else {
+            $this->assertEquals(
+                getenv('HOME') . DIRECTORY_SEPARATOR . Defaults::CONFIGURATION_FILE,
+                $this->filesystem->getDefaultConfigurationFile()
+            );
+        }
+    }
+
+    public function testHasDefaultConfigurationFile()
+    {
+        $this->assertFalse($this->filesystem->hasDefaultConfigurationFile());
+    }
+}

--- a/tests/stubs/config/complete.stub
+++ b/tests/stubs/config/complete.stub
@@ -1,0 +1,14 @@
+namespace: Vendor\Project
+test-framework: phpspec
+license: MIT
+php: 5.6
+
+construct-with:
+  - git
+  - phpcs
+  - vagrant
+  - editor-config
+  - env
+  - lgtm
+  - github-templates
+  - code-of-conduct

--- a/tests/stubs/config/php+testframework+licenceless.stub
+++ b/tests/stubs/config/php+testframework+licenceless.stub
@@ -1,0 +1,10 @@
+namespace: Vendor\Project
+
+construct-with:
+  - git
+  - phpcs
+  - vagrant
+  - editor-config
+  - env
+  - lgtm
+  - github-templates


### PR DESCRIPTION
Currently lacks the feature to overwrite single options provided to the `ConstructCommand`, which requires to modify variations directly in the `.construct` configuration file.

Also changed the option name from the proposed `--configuration` to `--config`. It's also possible to disable the usage of the default `.construct` configuration file via the `--ignore-default-config` option or its equivalent short option `-i`.
