### PR TITLE
Avoid broken Travis builds by using minor PHP versions. Fixes #85.

### DIFF
--- a/src/Commands/ConstructCommand.php
+++ b/src/Commands/ConstructCommand.php
@@ -64,7 +64,7 @@ class ConstructCommand extends Command
         $this->construct = $construct;
         $this->str = $str;
         $this->defaults = new Defaults();
-        $this->systemPhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+        $this->systemPhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
 
         parent::__construct();
     }

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -178,6 +178,6 @@ class Str
      */
     public function phpVersionIsValid($version)
     {
-        return preg_match('/\d\.\d\.\d/', $version) === 1;
+        return preg_match('/\d\.\d(\.\d)?/', $version) === 1;
     }
 }

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -19,7 +19,7 @@ class ConstructCommandTest extends PHPUnit
     protected function setUp()
     {
         $this->filesystem = Mockery::mock('JonathanTorres\Construct\Helpers\Filesystem');
-        $this->systemPhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION;
+        $this->systemPhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
     }
 
     protected function tearDown()

--- a/tests/Helpers/StrTest.php
+++ b/tests/Helpers/StrTest.php
@@ -131,6 +131,7 @@ class StrTest extends PHPUnit
         $this->assertTrue($this->str->phpVersionIsValid('5.5.0'));
         $this->assertTrue($this->str->phpVersionIsValid('5.5.9'));
         $this->assertTrue($this->str->phpVersionIsValid('5.6.0'));
+        $this->assertTrue($this->str->phpVersionIsValid('5.6'));
         $this->assertFalse($this->str->phpVersionIsValid('invalid'));
     }
 


### PR DESCRIPTION
Switched to minor PHP versions to avoid broken Travis builds.
