### PR TITLE
Revealed intent with intermediate --test-framework option. Closes #96.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### v1.9.0 `2016-04-dd`
+- `Fixes`
+    - User can use the more intent revealing option alias `--test-framework` to select a testing framework. The `--test` option will be removed in a future release. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#96](https://github.com/jonathantorres/construct/issues/96).
+
 #### v1.8.0 `2016-03-12`
 - `Added`
     - User can optionally generate [GitHub templates](https://github.com/blog/2111-issue-and-pull-request-templates). Done by [@raphaelstolt](https://github.com/raphaelstolt).

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ The generated project structure will look like the following `tree` excerpt. Fil
 This is a good starting point. You can continue your work from there.
 
 ## Select testing framework
-The `--test` option will allow you to select a testing framework. One of the following is available at the moment: `phpunit`, `phpspec`, `codeception` or `behat`. `phpunit` is currently the default.
+The `--test-framework` or `--test` option will allow you to select a testing framework. One of the following is available at the moment: `phpunit`, `phpspec`, `codeception` or `behat`. `phpunit` is currently the default.
 
 ```bash
-construct generate jonathantorres/logger --test=codeception
+construct generate jonathantorres/logger --test-framework=codeception
 ```
 
 You can also use the short option `-t`.

--- a/src/Commands/ConstructCommand.php
+++ b/src/Commands/ConstructCommand.php
@@ -77,7 +77,7 @@ class ConstructCommand extends Command
     protected function configure()
     {
         $nameDescription = 'The vendor/project name';
-        $testDescription = 'Testing framework (one of: ' . join(', ', $this->defaults->testingFrameworks) . ')';
+        $testFrameworkDescription = 'Testing framework (one of: ' . join(', ', $this->defaults->testingFrameworks) . ')';
         $licenseDescription = 'License (one of: ' . join(', ', $this->defaults->licenses) . ')';
         $namespaceDescription = 'Namespace for project';
         $gitDescription = 'Initialize an empty Git repo';
@@ -93,7 +93,8 @@ class ConstructCommand extends Command
         $this->setName('generate');
         $this->setDescription('Generates a basic PHP project');
         $this->addArgument('name', InputArgument::REQUIRED, $nameDescription);
-        $this->addOption('test', 't', InputOption::VALUE_OPTIONAL, $testDescription, 'phpunit');
+        $this->addOption('test', 't', InputOption::VALUE_OPTIONAL, $testFrameworkDescription, 'phpunit');
+        $this->addOption('test-framework', null, InputOption::VALUE_OPTIONAL, $testFrameworkDescription, 'phpunit');
         $this->addOption('license', 'l', InputOption::VALUE_OPTIONAL, $licenseDescription, 'MIT');
         $this->addOption('namespace', 's', InputOption::VALUE_OPTIONAL, $namespaceDescription, 'Vendor\Project');
         $this->addOption('git', 'g', InputOption::VALUE_NONE, $gitDescription);
@@ -119,6 +120,12 @@ class ConstructCommand extends Command
     {
         $projectName = $input->getArgument('name');
         $testFramework = $input->getOption('test');
+
+        $testingFramework = $input->getOption('test-framework');
+        if ($testingFramework !== 'phpunit') {
+            $testFramework = $testingFramework;
+        }
+
         $license = $input->getOption('license');
         $namespace = $input->getOption('namespace');
         $git = $input->getOption('git');

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -125,6 +125,23 @@ class ConstructCommandTest extends PHPUnit
         $this->assertSame($output, $commandTester->getDisplay());
     }
 
+    public function testProjectGenerationWithASpecifiedTestingFrameworkViaAlias()
+    {
+        $this->setMocks(2, 2, 1, 8, 8);
+
+        $app = $this->setApplication();
+        $command = $app->find('generate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute([
+            'command' => $command->getName(),
+            'name' => 'vendor/project',
+            '--test-framework' => 'behat'
+        ]);
+
+        $output = 'Initialized behat.' . PHP_EOL . 'Project "vendor/project" constructed.' . PHP_EOL;
+        $this->assertSame($output, $commandTester->getDisplay());
+    }
+
     public function testProjectGenerationWithSpecifiedPhpVersion()
     {
         $this->setMocks(3, 2);


### PR DESCRIPTION
Introduced intermediate `test-framework` option. Option `test` should be removed in a future release and the short option `t` should than be moved to the `test-framework`option.
