### PR TITLE
Initial Code of Conduct implementation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 #### v1.9.0 `2016-04-dd`
+- `Added`
+    - User can optionally generate a Code of Conduct file which is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4. Done by [@raphaelstolt](https://github.com/raphaelstolt).
 - `Fixes`
     - User can use the more intent revealing option alias `--test-framework` to select a testing framework. The `--test` option will be removed in a future release. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#96](https://github.com/jonathantorres/construct/issues/96).
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The generated project structure will look like the following `tree` excerpt. Fil
 ```
 ├── logger
 │   ├── CHANGELOG.md
+│   ├── (CONDUCT.md)
 │   ├── composer.json
 │   ├── composer.lock
 │   ├── CONTRIBUTING.md
@@ -181,6 +182,13 @@ The `--github-templates` option will generate [GitHub template](https://github.c
 
 ```bash
 construct generate jonathantorres/logger --github-templates
+```
+
+## Generate a Code of Conduct?
+The `--code-of-conduct` option will generate a Code of Conduct file named `CONDUCT.md` within the constructed project and also add a reference to it in the generated `README.md`. The used Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4. There's no short option available.
+
+```bash
+construct generate jonathantorres/logger --code-of-conduct
 ```
 
 ## Interactive Mode

--- a/src/Commands/ConstructCommand.php
+++ b/src/Commands/ConstructCommand.php
@@ -89,6 +89,7 @@ class ConstructCommand extends Command
         $environmentDescription = 'Generate .env environment files';
         $lgtmDescription = 'Generate LGTM configuration files';
         $githubTemplatesDescription = 'Generate GitHub templates';
+        $codeOfConductDescription = 'Generate Code of Conduct file';
 
         $this->setName('generate');
         $this->setDescription('Generates a basic PHP project');
@@ -106,6 +107,7 @@ class ConstructCommand extends Command
         $this->addOption('env', null, InputOption::VALUE_NONE, $environmentDescription);
         $this->addOption('lgtm', null, InputOption::VALUE_NONE, $lgtmDescription);
         $this->addOption('github-templates', null, InputOption::VALUE_NONE, $githubTemplatesDescription);
+        $this->addOption('code-of-conduct', null, InputOption::VALUE_NONE, $codeOfConductDescription);
     }
 
     /**
@@ -137,6 +139,7 @@ class ConstructCommand extends Command
         $environment = $input->getOption('env');
         $lgtm = $input->getOption('lgtm');
         $githubTemplates = $input->getOption('github-templates');
+        $codeOfConduct = $input->getOption('code-of-conduct');
 
         if (!$this->str->isValid($projectName)) {
             $output->writeln('<error>Warning: "' . $projectName . '" is not a valid project name, please use "vendor/project"</error>');
@@ -162,7 +165,8 @@ class ConstructCommand extends Command
             $phpVersion,
             $environment,
             $lgtm,
-            $githubTemplates
+            $githubTemplates,
+            $codeOfConduct
         );
 
         $this->construct->generate($this->settings, new Git, new Script);

--- a/src/Commands/InteractiveCommand.php
+++ b/src/Commands/InteractiveCommand.php
@@ -121,6 +121,7 @@ class InteractiveCommand extends Command
         $environmentFileQuestion = new ConfirmationQuestion('Do you want to generate an .env file?', false);
         $lgtmFileQuestion = new ConfirmationQuestion('Do you want to generate an LGTM configuration file?', false);
         $githubTemplatesQuestion = new ConfirmationQuestion('Do you want to generate GitHub templates?', false);
+        $codeOfConductQuestion = new ConfirmationQuestion('Do you want to add a Code of Conduct file?', false);
 
         $projectName = $helper->ask($input, $output, $projectNameQuestion);
         $testingFramework = $helper->ask($input, $output, $testingFrameworkQuestion);
@@ -135,6 +136,7 @@ class InteractiveCommand extends Command
         $environmentFile = $helper->ask($input, $output, $environmentFileQuestion);
         $lgtmFile = $helper->ask($input, $output, $lgtmFileQuestion);
         $githubTemplates = $helper->ask($input, $output, $githubTemplatesQuestion);
+        $codeOfConduct = $helper->ask($input, $output, $codeOfConductQuestion);
 
         $this->settings = new Settings(
             $projectName,
@@ -149,7 +151,8 @@ class InteractiveCommand extends Command
             $phpVersion,
             $environmentFile,
             $lgtmFile,
-            $githubTemplates
+            $githubTemplates,
+            $codeOfConduct
         );
 
         $output->writeln('Creating your project...');

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -114,7 +114,7 @@ class Construct
         $this->saveNames();
         $this->root();
         $this->src();
-        $this->docs();
+        $this->docs($this->settings->withCodeOfConduct());
         $this->gitignore();
         $this->testing();
 
@@ -140,6 +140,10 @@ class Construct
 
         if ($this->settings->withGithubTemplates()) {
             $this->githubTemplates();
+        }
+
+        if ($this->settings->withCodeOfConduct()) {
+            $this->codeOfConduct();
         }
 
         $this->travis();
@@ -194,11 +198,13 @@ class Construct
     /**
      * Generate documentation (README, CONTRIBUTING, CHANGELOG) files.
      *
+     * @param boolean $withCodeOfConduct Whether or not to set a reference to the Code of Conduct in the readme.
+     *
      * @return void
      */
-    protected function docs()
+    protected function docs($withCodeOfConduct = false)
     {
-        $this->readme();
+        $this->readme($withCodeOfConduct);
         $this->contributing();
         $this->changelog();
     }
@@ -206,11 +212,18 @@ class Construct
     /**
      * Generate README.md file.
      *
+     * @param boolean $withCodeOfConduct Whether or not to set a reference to the Code of Conduct in the readme.
+     *
      * @return void
      */
-    protected function readme()
+    protected function readme($withCodeOfConduct = false)
     {
-        $readme = $this->file->get(__DIR__ . '/stubs/README.stub');
+        if ($withCodeOfConduct === false) {
+            $readme = $this->file->get(__DIR__ . '/stubs/README.stub');
+        } else {
+            $readme = $this->file->get(__DIR__ . '/stubs/README.CONDUCT.stub');
+        }
+
         $stubs = [
             '{project_upper}',
             '{license}',
@@ -638,6 +651,21 @@ class Construct
         unset($this->exportIgnores[$index]);
 
         $this->exportIgnores[] = '.github/*';
+    }
+
+    /**
+     * Generate Code of Conduct file.
+     *
+     * @return void
+     */
+    protected function codeOfConduct()
+    {
+        $this->file->copy(
+            __DIR__ . '/stubs/CONDUCT.stub',
+            $this->projectLower . '/' . 'CONDUCT.md'
+        );
+
+        $this->exportIgnores[] = 'CONDUCT.md';
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -96,6 +96,13 @@ class Settings
     private $githubTemplates;
 
     /**
+     * Generate Code of Conduct file?
+     *
+     * @var boolean
+     */
+    private $codeOfConduct;
+
+    /**
      * Initialize.
      *
      * @param string  $projectName        The entered project name.
@@ -111,6 +118,7 @@ class Settings
      * @param boolean $environmentFiles   Generate .env environment files?
      * @param boolean $lgtmConfiguration  Generate LGTM configuration files?
      * @param boolean $githubTemplates    Generate GitHub templates?
+     * @param boolean $codeOfConduct      Generate Code of Conduct file?
      *
      * @return void
      */
@@ -127,7 +135,8 @@ class Settings
         $phpVersion,
         $environmentFiles,
         $lgtmConfiguration,
-        $githubTemplates = false
+        $githubTemplates = false,
+        $codeOfConduct = false
     ) {
         $this->projectName = $projectName;
         $this->testingFramework = $testingFramework;
@@ -142,6 +151,7 @@ class Settings
         $this->environmentFiles = $environmentFiles;
         $this->lgtmConfiguration = $lgtmConfiguration;
         $this->githubTemplates = $githubTemplates;
+        $this->codeOfConduct = $codeOfConduct;
     }
 
     /**
@@ -272,5 +282,15 @@ class Settings
     public function withGithubTemplates()
     {
         return $this->githubTemplates;
+    }
+
+    /**
+     * Whether or not to create a Code of Conduct file.
+     *
+     * @return boolean
+     */
+    public function withCodeOfConduct()
+    {
+        return $this->codeOfConduct;
     }
 }

--- a/src/stubs/CONDUCT.stub
+++ b/src/stubs/CONDUCT.stub
@@ -1,0 +1,71 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4,
+available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/).

--- a/src/stubs/README.CONDUCT.stub
+++ b/src/stubs/README.CONDUCT.stub
@@ -1,0 +1,25 @@
+{project_upper}
+================
+This is where your library description should go. Try to limit it to a paragraph or two.
+
+#### Installation via Composer
+``` bash
+$ composer require {vendor_lower}/{project_lower}
+```
+
+#### Changelog
+Please see [CHANGELOG](CHANGELOG.md) for more information.
+
+#### Running tests
+``` bash
+$ composer test
+```
+
+#### Code of Conduct
+Please see [CONDUCT](CONDUCT.md) for more details.
+
+#### Contributing
+Please see [CONTRIBUTING](CONTRIBUTING.md) for more details.
+
+#### License
+This library is licensed under the {license} license. Please see [LICENSE](LICENSE.md) for more information.

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -523,6 +523,40 @@ class ConstructTest extends PHPUnit
         );
     }
 
+    public function testProjectGenerationWithCodeOfConduct()
+    {
+        $settings = new Settings(
+            'jonathantorres/logger',
+            'phpunit',
+            'MIT',
+            'Vendor\Project',
+            null,
+            null,
+            null,
+            null,
+            false,
+            '5.6.0',
+            null,
+            false,
+            false,
+            true
+        );
+
+        $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
+        $this->assertSame(
+            $this->getStub('with-code-of-conduct/CONDUCT'),
+            $this->getFile('CONDUCT.md')
+        );
+        $this->assertSame(
+            $this->getStub('with-code-of-conduct/README'),
+            $this->getFile('README.md')
+        );
+        $this->assertSame(
+            $this->getStub('with-code-of-conduct/gitattributes'),
+            $this->getFile('.gitattributes')
+        );
+    }
+
     /**
      * Get expected changelog file.
      *

--- a/tests/stubs/with-code-of-conduct/CONDUCT.stub
+++ b/tests/stubs/with-code-of-conduct/CONDUCT.stub
@@ -1,0 +1,71 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4,
+available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/).

--- a/tests/stubs/with-code-of-conduct/README.stub
+++ b/tests/stubs/with-code-of-conduct/README.stub
@@ -1,0 +1,25 @@
+Logger
+================
+This is where your library description should go. Try to limit it to a paragraph or two.
+
+#### Installation via Composer
+``` bash
+$ composer require jonathantorres/logger
+```
+
+#### Changelog
+Please see [CHANGELOG](CHANGELOG.md) for more information.
+
+#### Running tests
+``` bash
+$ composer test
+```
+
+#### Code of Conduct
+Please see [CONDUCT](CONDUCT.md) for more details.
+
+#### Contributing
+Please see [CONTRIBUTING](CONTRIBUTING.md) for more details.
+
+#### License
+This library is licensed under the MIT license. Please see [LICENSE](LICENSE.md) for more information.

--- a/tests/stubs/with-code-of-conduct/gitattributes.stub
+++ b/tests/stubs/with-code-of-conduct/gitattributes.stub
@@ -1,0 +1,12 @@
+* text=auto
+
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/CHANGELOG.md export-ignore
+/CONDUCT.md export-ignore
+/CONTRIBUTING.md export-ignore
+/LICENSE.md export-ignore
+/README.md export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore


### PR DESCRIPTION
Added a `--code-of-conduct` option for e.g. community driven projects which might require a Code of Conduct.

The option / key needs to be added to the configuration once merged.
