### PR TITLE
Corrected link to contributing file. Fixes #105.

### DIFF
--- a/src/Construct.php
+++ b/src/Construct.php
@@ -114,7 +114,7 @@ class Construct
         $this->saveNames();
         $this->root();
         $this->src();
-        $this->docs($this->settings->withCodeOfConduct());
+        $this->docs();
         $this->gitignore();
         $this->testing();
 
@@ -198,13 +198,11 @@ class Construct
     /**
      * Generate documentation (README, CONTRIBUTING, CHANGELOG) files.
      *
-     * @param boolean $withCodeOfConduct Whether or not to set a reference to the Code of Conduct in the readme.
-     *
      * @return void
      */
-    protected function docs($withCodeOfConduct = false)
+    protected function docs()
     {
-        $this->readme($withCodeOfConduct);
+        $this->readme();
         $this->contributing();
         $this->changelog();
     }
@@ -212,16 +210,20 @@ class Construct
     /**
      * Generate README.md file.
      *
-     * @param boolean $withCodeOfConduct Whether or not to set a reference to the Code of Conduct in the readme.
-     *
      * @return void
      */
-    protected function readme($withCodeOfConduct = false)
+    protected function readme()
     {
-        if ($withCodeOfConduct === false) {
+        if ($this->settings->withCodeOfConduct() === false && $this->settings->withGithubTemplates() === false) {
             $readme = $this->file->get(__DIR__ . '/stubs/README.stub');
-        } else {
+        } elseif ($this->settings->withCodeOfConduct() === false && $this->settings->
+            withGithubTemplates() === true) {
+            $readme = $this->file->get(__DIR__ . '/stubs/README.GITHUB.TEMPLATES.stub');
+        } elseif ($this->settings->withCodeOfConduct() === true && $this->settings->
+            withGithubTemplates() === false) {
             $readme = $this->file->get(__DIR__ . '/stubs/README.CONDUCT.stub');
+        } else {
+            $readme = $this->file->get(__DIR__ . '/stubs/README.CONDUCT.GITHUB.TEMPLATES.stub');
         }
 
         $stubs = [

--- a/src/stubs/README.CONDUCT.GITHUB.TEMPLATES.stub
+++ b/src/stubs/README.CONDUCT.GITHUB.TEMPLATES.stub
@@ -1,0 +1,25 @@
+{project_upper}
+================
+This is where your library description should go. Try to limit it to a paragraph or two.
+
+#### Installation via Composer
+``` bash
+$ composer require {vendor_lower}/{project_lower}
+```
+
+#### Changelog
+Please see [CHANGELOG](CHANGELOG.md) for more information.
+
+#### Running tests
+``` bash
+$ composer test
+```
+
+#### Code of Conduct
+Please see [CONDUCT](CONDUCT.md) for more details.
+
+#### Contributing
+Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for more details.
+
+#### License
+This library is licensed under the {license} license. Please see [LICENSE](LICENSE.md) for more information.

--- a/src/stubs/README.GITHUB.TEMPLATES.stub
+++ b/src/stubs/README.GITHUB.TEMPLATES.stub
@@ -1,0 +1,22 @@
+{project_upper}
+================
+This is where your library description should go. Try to limit it to a paragraph or two.
+
+#### Installation via Composer
+``` bash
+$ composer require {vendor_lower}/{project_lower}
+```
+
+#### Changelog
+Please see [CHANGELOG](CHANGELOG.md) for more information.
+
+#### Running tests
+``` bash
+$ composer test
+```
+
+#### Contributing
+Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for more details.
+
+#### License
+This library is licensed under the {license} license. Please see [LICENSE](LICENSE.md) for more information.

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -521,6 +521,10 @@ class ConstructTest extends PHPUnit
             $this->getStub('with-github-templates/gitattributes'),
             $this->getFile('.gitattributes')
         );
+        $this->assertSame(
+            $this->getStub('with-github-templates/README'),
+            $this->getFile('README.md')
+        );
     }
 
     public function testProjectGenerationWithCodeOfConduct()
@@ -554,6 +558,36 @@ class ConstructTest extends PHPUnit
         $this->assertSame(
             $this->getStub('with-code-of-conduct/gitattributes'),
             $this->getFile('.gitattributes')
+        );
+    }
+
+    public function testProjectGenerationWithCodeOfConductAndGitHubTemplates()
+    {
+        $settings = new Settings(
+            'jonathantorres/logger',
+            'phpunit',
+            'MIT',
+            'Vendor\Project',
+            null,
+            null,
+            null,
+            null,
+            false,
+            '5.6.0',
+            null,
+            false,
+            true,
+            true
+        );
+
+        $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
+        $this->assertSame(
+            $this->getStub('with-code-of-conduct/CONDUCT'),
+            $this->getFile('CONDUCT.md')
+        );
+        $this->assertSame(
+            $this->getStub('with-code-of-conduct-and-github-templates/README'),
+            $this->getFile('README.md')
         );
     }
 

--- a/tests/stubs/with-code-of-conduct-and-github-templates/README.stub
+++ b/tests/stubs/with-code-of-conduct-and-github-templates/README.stub
@@ -1,0 +1,25 @@
+Logger
+================
+This is where your library description should go. Try to limit it to a paragraph or two.
+
+#### Installation via Composer
+``` bash
+$ composer require jonathantorres/logger
+```
+
+#### Changelog
+Please see [CHANGELOG](CHANGELOG.md) for more information.
+
+#### Running tests
+``` bash
+$ composer test
+```
+
+#### Code of Conduct
+Please see [CONDUCT](CONDUCT.md) for more details.
+
+#### Contributing
+Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for more details.
+
+#### License
+This library is licensed under the MIT license. Please see [LICENSE](LICENSE.md) for more information.

--- a/tests/stubs/with-github-templates/README.stub
+++ b/tests/stubs/with-github-templates/README.stub
@@ -1,0 +1,22 @@
+Logger
+================
+This is where your library description should go. Try to limit it to a paragraph or two.
+
+#### Installation via Composer
+``` bash
+$ composer require jonathantorres/logger
+```
+
+#### Changelog
+Please see [CHANGELOG](CHANGELOG.md) for more information.
+
+#### Running tests
+``` bash
+$ composer test
+```
+
+#### Contributing
+Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for more details.
+
+#### License
+This library is licensed under the MIT license. Please see [LICENSE](LICENSE.md) for more information.


### PR DESCRIPTION
The `CONTRIBUTING.md` inside the `.github` directory is now referenced.
