### PR TITLE
Constructed .env is added to .gitignore. Fixes #117.

### DIFF
--- a/src/Construct.php
+++ b/src/Construct.php
@@ -284,7 +284,15 @@ class Construct
      */
     protected function gitignore()
     {
-        $this->file->copy(__DIR__ . '/stubs/gitignore.stub', $this->projectLower . '/' . '.gitignore');
+        if ($this->settings->withEnvironmentFiles()) {
+            $content = $this->file->get(__DIR__ . '/stubs/gitignore.stub');
+            $content .= '.env' . PHP_EOL;
+
+            $this->file->put($this->projectLower . '/' . '.gitignore', $content);
+        } else {
+            $this->file->copy(__DIR__ . '/stubs/gitignore.stub', $this->projectLower . '/' . '.gitignore');
+        }
+
         $this->exportIgnores[] = '.gitignore';
     }
 

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -300,7 +300,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithEnvironmentFiles()
     {
-        $this->setMocks(3, 2, 3);
+        $this->setMocks(3, 2, 2, 11, 11);
 
         $app = $this->setApplication();
         $command = $app->find('generate');

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -465,6 +465,7 @@ class ConstructTest extends PHPUnit
         $this->assertSame($this->getStub('with-env/env'), $this->getFile('.env.example'));
         $this->assertSame($this->getStub('with-env/gitattributes'), $this->getFile('.gitattributes'));
         $this->assertSame($this->getStub('with-env/composer'), $this->getFile('composer.json'));
+        $this->assertSame($this->getStub('with-env/gitignore'), $this->getFile('.gitignore'));
     }
 
     public function testProjectGenerationWithLgtmConfiguration()

--- a/tests/stubs/with-env/gitignore.stub
+++ b/tests/stubs/with-env/gitignore.stub
@@ -1,0 +1,4 @@
+# composer
+/vendor/
+phpunit.xml
+.env


### PR DESCRIPTION
It is now ensured that no in `.env` located secrets make it into the Git repository by an accidentally commit.
