### PR TITLE
Disabled Xdebug in constructed Travis CI configuration. Fixes #119.

### DIFF
--- a/src/stubs/travis.stub
+++ b/src/stubs/travis.stub
@@ -4,6 +4,7 @@ php:
 {phpVersions}
 
 before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.php54.stub
+++ b/tests/stubs/travis.php54.stub
@@ -9,6 +9,7 @@ php:
   - 7.0
 
 before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.php55.stub
+++ b/tests/stubs/travis.php55.stub
@@ -8,6 +8,7 @@ php:
   - 7.0
 
 before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.php56.stub
+++ b/tests/stubs/travis.php56.stub
@@ -7,6 +7,7 @@ php:
   - 7.0
 
 before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.php7.stub
+++ b/tests/stubs/travis.php7.stub
@@ -6,6 +6,7 @@ php:
   - 7.0
 
 before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.stub
+++ b/tests/stubs/travis.stub
@@ -7,6 +7,7 @@ php:
   - 7.0
 
 before_script:
+  - if [ $TRAVIS_PHP_VERSION != "hhvm" ]; then phpenv config-rm xdebug.ini ; fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 


### PR DESCRIPTION
Xdebug is now also disabled in constructed Travis CI configuration.
