### PR TITLE
Validate settings from configuration file. Fixes #126.

### DIFF
--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -45,7 +45,7 @@ class ConfigurationTest extends PHPUnit
             'composer,keywords',
             true,
             true,
-            '5.6',
+            '5.4',
             true,
             true,
             true,

--- a/tests/stubs/config/complete.stub
+++ b/tests/stubs/config/complete.stub
@@ -1,7 +1,7 @@
 namespace: Vendor\Project
 test-framework: phpspec
 license: MIT
-php: 5.6
+php: 5.4
 
 construct-with:
   - git

--- a/tests/stubs/config/invalid_settings.stub
+++ b/tests/stubs/config/invalid_settings.stub
@@ -1,0 +1,14 @@
+namespace: Vendor
+test-framework: rspec
+license: DOO_WUTCH_YA_LIKE
+php: 2.a
+
+construct-with:
+  - git
+  - phpcs
+  - vagrant
+  - editor-config
+  - env
+  - lgtm
+  - github-templates
+  - code-of-conduct


### PR DESCRIPTION
The `license`, `testing framework`, and `PHP version` are also validated from the configuration file.
