### PR TITLE
Fix misleading documentation. Fixes #128.

### DIFF
--- a/example/.construct
+++ b/example/.construct
@@ -1,4 +1,4 @@
-namespace: Vendor\Project
+namespace: Namespace
 test-framework: phpspec
 license: MIT
 php: 5.6

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -39,7 +39,7 @@ class ConfigurationTest extends PHPUnit
             'example-project',
             'phpspec',
             'MIT',
-            'Vendor\Project',
+            'Namespace',
             true,
             true,
             'composer,keywords',

--- a/tests/stubs/config/complete.stub
+++ b/tests/stubs/config/complete.stub
@@ -1,4 +1,4 @@
-namespace: Vendor\Project
+namespace: Namespace
 test-framework: phpspec
 license: MIT
 php: 5.6

--- a/tests/stubs/config/php+testframework+licenceless.stub
+++ b/tests/stubs/config/php+testframework+licenceless.stub
@@ -1,4 +1,4 @@
-namespace: Vendor\Project
+namespace: Namespace
 
 construct-with:
   - git


### PR DESCRIPTION
Currently there's no way to configure a _reoccurring_ vendor in the configuration file.
