### PR TITLE
Refactor towards runtime determined requirement versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ composer global require jonathantorres/construct
 
 Make sure that `~/.composer/vendor/bin` is on your `$PATH`. This way the `construct` executable can be located.
 
+## Assumptions
+
+As Construct utilizes the Composer CLI it's assumed that Composer is installed. When using the option to initialize an empty Git repo (i.e. `--git` or `-g`) it's also assumed that Git is installed.
+
 ## Usage
 Just run `construct generate` with your `vendor/package` declaration and it will construct a basic PHP project into the `package` directory. For example, if you run `construct generate jonathantorres/logger` it will generate a basic project structure inside the `logger` folder.
 

--- a/src/Helpers/Script.php
+++ b/src/Helpers/Script.php
@@ -5,15 +5,21 @@ namespace JonathanTorres\Construct\Helpers;
 class Script
 {
     /**
-     * Do an initial composer install in constructed project.
+     * Do an initial composer install in constructed project and require
+     * the development packages.
      *
-     * @param string $folder
+     * @param string $folder   The folder to execute the command(s) in.
+     * @param array  $packages The development packages to require.
      *
      * @return void
      */
-    public function runComposerInstall($folder)
+    public function runComposerInstallAndRequireDevelopmentPackages($folder, array $packages)
     {
         $command = 'cd ' . $folder . ' && composer install';
+
+        if (count($packages) > 0) {
+            $command .= ' && composer require --dev ' . implode(' ', $packages);
+        }
 
         exec($command);
     }

--- a/src/stubs/composer/composer.behat.stub
+++ b/src/stubs/composer/composer.behat.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">={php_version}"
     },
-    "require-dev": {
-        "{testing}/{testing}": "{testing_version}"
-    },
     "autoload": {
         "psr-4": {
             "{namespace}\\": "src/"

--- a/src/stubs/composer/composer.codeception.stub
+++ b/src/stubs/composer/composer.codeception.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">={php_version}"
     },
-    "require-dev": {
-        "{testing}/{testing}": "{testing_version}"
-    },
     "autoload": {
         "psr-4": {
             "{namespace}\\": "src/"

--- a/src/stubs/composer/composer.phpspec.stub
+++ b/src/stubs/composer/composer.phpspec.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">={php_version}"
     },
-    "require-dev": {
-        "{testing}/{testing}": "{testing_version}"
-    },
     "autoload": {
         "psr-4": {
             "{namespace}\\": "src/"

--- a/src/stubs/composer/composer.phpunit.stub
+++ b/src/stubs/composer/composer.phpunit.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">={php_version}"
     },
-    "require-dev": {
-        "{testing}/{testing}": "{testing_version}"
-    },
     "autoload": {
         "psr-4": {
             "{namespace}\\": "src/"

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -29,7 +29,6 @@ class ConstructTest extends PHPUnit
         $this->str = new Str;
         $this->construct = new Construct(new Filesystem, $this->str);
         $this->scriptHelper = Mockery::mock('JonathanTorres\Construct\Helpers\Script');
-        $this->scriptHelper->shouldReceive('runComposerInstall')->once()->with('logger')->andReturnNull();
         $this->gitHelper = Mockery::mock('JonathanTorres\Construct\Helpers\Git');
         $this->gitHelper->shouldReceive('getUser')->twice()->withNoArgs()->andReturn($this->gitUser);
     }
@@ -56,6 +55,24 @@ class ConstructTest extends PHPUnit
         rmdir($path);
     }
 
+    /**
+     * Sets the Mockery expectation for runComposerInstallAndRequireDevelopmentPackages
+     * of the script helper mock.
+     *
+     * @param  array $packages The require dev packages to inject. Defaults to
+     *                         ['phpunit/phpunit'].
+     * @return void
+     */
+    private function setScriptHelperComposerInstallExpectationWithPackages(
+        array $packages = ['phpunit/phpunit']
+    ) {
+        $this->scriptHelper
+            ->shouldReceive('runComposerInstallAndRequireDevelopmentPackages')
+            ->once()
+            ->with('logger', $packages)
+            ->andReturnNull();
+    }
+
     public function testBasicProjectIsGenerated()
     {
         $settings = new Settings(
@@ -72,6 +89,8 @@ class ConstructTest extends PHPUnit
             null,
             null
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('README'), $this->getFile('README.md'));
@@ -104,6 +123,7 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages(['behat/behat']);
         $this->scriptHelper->shouldReceive('initBehat')->once()->with('logger')->andReturnNull();
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('composer.behat'), $this->getFile('composer.json'));
@@ -126,6 +146,9 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages(
+            ['codeception/codeception']
+        );
         $this->scriptHelper->shouldReceive('bootstrapCodeception')->once()->with('logger')->andReturnNull();
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('composer.codeception'), $this->getFile('composer.json'));
@@ -146,6 +169,10 @@ class ConstructTest extends PHPUnit
             '5.6.0',
             null,
             null
+        );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages(
+            ['phpspec/phpspec']
         );
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
@@ -170,6 +197,8 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('LICENSE.Apache'), $this->getFile('LICENSE.md'));
     }
@@ -190,6 +219,8 @@ class ConstructTest extends PHPUnit
             null,
             null
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('LICENSE.Gpl2'), $this->getFile('LICENSE.md'));
@@ -212,6 +243,8 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('LICENSE.Gpl3'), $this->getFile('LICENSE.md'));
     }
@@ -232,6 +265,8 @@ class ConstructTest extends PHPUnit
             null,
             null
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('with-namespace/composer'), $this->getFile('composer.json'));
@@ -256,6 +291,7 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
         $this->gitHelper->shouldReceive('init')->once()->with('logger')->andReturnNull();
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
     }
@@ -275,6 +311,10 @@ class ConstructTest extends PHPUnit
             '5.6.0',
             null,
             null
+        );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages(
+            ['phpunit/phpunit', 'friendsofphp/php-cs-fixer']
         );
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
@@ -307,6 +347,8 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('composer.keywords'), $this->getFile('composer.json'));
     }
@@ -327,6 +369,8 @@ class ConstructTest extends PHPUnit
             null,
             null
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('with-vagrant/Vagrantfile'), $this->getFile('Vagrantfile'));
@@ -350,6 +394,8 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('with-editorconfig/editorconfig'), $this->getFile('.editorconfig'));
         $this->assertSame($this->getStub('with-editorconfig/gitattributes'), $this->getFile('.gitattributes'));
@@ -371,6 +417,8 @@ class ConstructTest extends PHPUnit
             null,
             null
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('composer.php54'), $this->getFile('composer.json'));
@@ -394,6 +442,8 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('composer.php55'), $this->getFile('composer.json'));
         $this->assertSame($this->getStub('travis.php55'), $this->getFile('.travis.yml'));
@@ -415,6 +465,8 @@ class ConstructTest extends PHPUnit
             null,
             null
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('composer.php56'), $this->getFile('composer.json'));
@@ -438,6 +490,8 @@ class ConstructTest extends PHPUnit
             null
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('composer.php7'), $this->getFile('composer.json'));
         $this->assertSame($this->getStub('travis.php7'), $this->getFile('.travis.yml'));
@@ -458,6 +512,10 @@ class ConstructTest extends PHPUnit
             '5.6.0',
             true,
             false
+        );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages(
+            ['phpunit/phpunit', 'vlucas/phpdotenv']
         );
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
@@ -485,6 +543,8 @@ class ConstructTest extends PHPUnit
             true
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame($this->getStub('with-lgtm/maintainers'), $this->getFile('MAINTAINERS'));
         $this->assertSame($this->getStub('with-lgtm/lgtm'), $this->getFile('.lgtm'));
@@ -508,6 +568,8 @@ class ConstructTest extends PHPUnit
             false,
             true
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame(
@@ -547,6 +609,8 @@ class ConstructTest extends PHPUnit
             true
         );
 
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame(
             $this->getStub('with-code-of-conduct/CONDUCT'),
@@ -580,6 +644,8 @@ class ConstructTest extends PHPUnit
             true,
             true
         );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
         $this->assertSame(

--- a/tests/stubs/composer.behat.stub
+++ b/tests/stubs/composer.behat.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "behat/behat": "~3.0"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.codeception.stub
+++ b/tests/stubs/composer.codeception.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "codeception/codeception": "2.1.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.keywords.stub
+++ b/tests/stubs/composer.keywords.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.php54.stub
+++ b/tests/stubs/composer.php54.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.4.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.php55.stub
+++ b/tests/stubs/composer.php55.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.5.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.php56.stub
+++ b/tests/stubs/composer.php56.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.php7.stub
+++ b/tests/stubs/composer.php7.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=7.0.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.phpspec.stub
+++ b/tests/stubs/composer.phpspec.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "phpspec/phpspec": "~2.0"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/composer.stub
+++ b/tests/stubs/composer.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/with-env/composer.stub
+++ b/tests/stubs/with-env/composer.stub
@@ -12,10 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*",
-        "vlucas/phpdotenv": "~2.1"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"

--- a/tests/stubs/with-namespace/composer.stub
+++ b/tests/stubs/with-namespace/composer.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Terminus\\Maximus\\Logger\\": "src/"

--- a/tests/stubs/with-phpcs/composer.stub
+++ b/tests/stubs/with-phpcs/composer.stub
@@ -12,9 +12,6 @@
     "require": {
         "php": ">=5.6.0"
     },
-    "require-dev": {
-        "phpunit/phpunit": "4.8.*"
-    },
     "autoload": {
         "psr-4": {
             "Jonathantorres\\Logger\\": "src/"


### PR DESCRIPTION
To avoid hard coded requirement versions this commit enables the utilization of the `composer require --dev <package(s)>` command to determine the latest package(s) version(s) at runtime.
