### PR TITLE
Add guidelines to generated file and own.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Thanks for contributing to construct! Just follow these single guidelines:
 
 - All features or bugfixes must have an associated issue for discussion. If you want to work on a issue that is already created, please leave a comment on it indicating that you are working on it.
 
+- You must use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.
+
 - Commit messages should read like a sentence, including the period, _ideally_ describing the why not the what.
     - Commits fixing bugs should reference a present issue via `Fixes #<bug-issue-number>.`.
     - Commits adding a feature or enhancement should reference a present issue via `Closes #<feature|enhancement-issue-number>.`.

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -253,7 +253,17 @@ class Construct
      */
     protected function contributing()
     {
-        $content = $this->file->get(__DIR__ . '/stubs/CONTRIBUTING.stub');
+        if ($this->settings->withPhpcsConfiguration()) {
+            $contributing = $this->file->get(__DIR__ . '/stubs/CONTRIBUTING.PHPCS.stub');
+        } else {
+            $contributing = $this->file->get(__DIR__ . '/stubs/CONTRIBUTING.stub');
+        }
+
+        $content = str_replace(
+            '{project_lower}',
+            $this->projectLower,
+            $contributing
+        );
 
         $this->file->put($this->projectLower . '/' . 'CONTRIBUTING.md', $content);
         $this->exportIgnores[] = 'CONTRIBUTING.md';

--- a/src/stubs/CONTRIBUTING.PHPCS.stub
+++ b/src/stubs/CONTRIBUTING.PHPCS.stub
@@ -1,6 +1,8 @@
 # How to contribute
 
-Thanks for contributing to logger! Just follow these single guidelines:
+Thanks for contributing to {project_lower}! Just follow these single guidelines:
 - You must follow the PSR-2 coding standard. More info [here](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
+
+- Ensure the coding standard compliance before committing or opening pull requests by running `composer cs-fix` in the root directory of this repository.
 
 - You must use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.

--- a/src/stubs/CONTRIBUTING.stub
+++ b/src/stubs/CONTRIBUTING.stub
@@ -1,1 +1,6 @@
 # How to contribute
+
+Thanks for contributing to {project_lower}! Just follow these single guidelines:
+- You must follow the PSR-2 coding standard. More info [here](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
+
+- You must use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -288,6 +288,10 @@ class ConstructTest extends PHPUnit
 
         $this->assertSame($this->getStub('with-phpcs/phpcs'), $this->getFile('.php_cs'));
         $this->assertSame($this->getStub('with-phpcs/gitattributes'), $this->getFile('.gitattributes'));
+        $this->assertSame(
+            $this->getStub('with-phpcs/CONTRIBUTING'),
+            $this->getFile('CONTRIBUTING.md')
+        );
     }
 
     public function testProjectGenerationWithComposerKeywords()

--- a/tests/stubs/with-phpcs/CONTRIBUTING.stub
+++ b/tests/stubs/with-phpcs/CONTRIBUTING.stub
@@ -3,4 +3,6 @@
 Thanks for contributing to logger! Just follow these single guidelines:
 - You must follow the PSR-2 coding standard. More info [here](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
 
+- Ensure the coding standard compliance before committing or opening pull requests by running `composer cs-fix` in the root directory of this repository.
+
 - You must use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.


### PR DESCRIPTION
Basic guidelines are written to generated `CONTRIBUTING.md` file, also adds guideline to use `feature/topic branches` on own file. 
