### PR TITLE
Refactor towards dynamic entries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - A Travis CI badge is now added in the constructed README.md.
 - `Fixed`
     - Generated `phpspec` configuration file has a `.dist` extension and a `specs` directory is created.
+    - The `.gitignore` entries are set dynamically and the non `dist` tests or specs configuration is ignored.
 
 #### v1.10.1 `2016-07-09`
 - `Fixed`

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -46,6 +46,13 @@ class Construct
     protected $exportIgnores = [];
 
     /**
+     * The directories and files to ignore in Git repositories.
+     *
+     * @var array
+     */
+    protected $gitIgnores = ['/vendor', 'composer.lock'];
+
+    /**
      * Camel case version of vendor name.
      * ex: JonathanTorres
      *
@@ -115,7 +122,6 @@ class Construct
         $this->root();
         $this->src();
         $this->docs();
-        $this->gitignore();
         $this->testing();
 
         if ($this->settings->withPhpcsConfiguration()) {
@@ -154,6 +160,7 @@ class Construct
         $this->license($git);
         $this->composer($git);
         $this->projectClass();
+        $this->gitignore();
         $this->gitattributes();
 
         if ($this->settings->withGitInit()) {
@@ -289,25 +296,6 @@ class Construct
 
         $this->file->put($this->projectLower . '/' . 'CHANGELOG.md', $content);
         $this->exportIgnores[] = 'CHANGELOG.md';
-    }
-
-    /**
-     * Generate gitignore file.
-     *
-     * @return void
-     */
-    protected function gitignore()
-    {
-        if ($this->settings->withEnvironmentFiles()) {
-            $content = $this->file->get(__DIR__ . '/stubs/gitignore.stub');
-            $content .= '.env' . PHP_EOL;
-
-            $this->file->put($this->projectLower . '/' . '.gitignore', $content);
-        } else {
-            $this->file->copy(__DIR__ . '/stubs/gitignore.stub', $this->projectLower . '/' . '.gitignore');
-        }
-
-        $this->exportIgnores[] = '.gitignore';
     }
 
     /**
@@ -495,6 +483,26 @@ class Construct
     }
 
     /**
+     * Generate gitignore file.
+     *
+     * @return void
+     */
+    protected function gitignore()
+    {
+        sort($this->gitIgnores, SORT_STRING | SORT_FLAG_CASE);
+
+        $content = '';
+
+        foreach ($this->gitIgnores as $ignore) {
+            $content .= $ignore . "\n";
+        }
+
+        $this->file->put($this->projectLower . '/' . '.gitignore', $content);
+
+        $this->exportIgnores[] = '.gitignore';
+    }
+
+    /**
      * Generate gitattributes file.
      *
      * @return void
@@ -620,6 +628,7 @@ class Construct
         );
 
         $this->exportIgnores[] = '.env';
+        $this->gitIgnores[] = '.env';
     }
 
     /**
@@ -726,6 +735,8 @@ class Construct
 
         $this->file->put($this->projectLower . '/' . 'phpunit.xml.dist', $content);
         $this->exportIgnores[] = 'phpunit.xml.dist';
+
+        $this->gitIgnores[] = 'phpunit.xml';
     }
 
     /**
@@ -746,6 +757,8 @@ class Construct
 
         $this->file->put($this->projectLower . '/' . 'phpspec.yml.dist', $content);
         $this->exportIgnores[] = 'phpspec.yml.dist';
+
+        $this->gitIgnores[] = 'phpspec.yml';
     }
 
     /**

--- a/src/stubs/gitignore.stub
+++ b/src/stubs/gitignore.stub
@@ -1,3 +1,0 @@
-# composer
-/vendor/
-phpunit.xml

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -112,7 +112,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithASpecifiedTestingFramework()
     {
-        $this->setMocks(2, 2, 1, 8, 8);
+        $this->setMocks(2, 2, 0, 8, 9);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -129,7 +129,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithASpecifiedTestingFrameworkViaAlias()
     {
-        $this->setMocks(2, 2, 1, 8, 8);
+        $this->setMocks(2, 2, 0, 8, 9);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -238,7 +238,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithPhpCs()
     {
-        $this->setMocks(3, 2, 2);
+        $this->setMocks(3, 2, 1);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -270,7 +270,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithVagrant()
     {
-        $this->setMocks(3, 2, 2);
+        $this->setMocks(3, 2, 1);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -286,7 +286,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithEditorConfig()
     {
-        $this->setMocks(3, 2, 2);
+        $this->setMocks(3, 2, 1);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -302,7 +302,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithEnvironmentFiles()
     {
-        $this->setMocks(3, 2, 2, 11, 11);
+        $this->setMocks(3, 2, 2, 10, 11);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -318,7 +318,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithGitHubTemplates()
     {
-        $this->setMocks(4, 2, 3);
+        $this->setMocks(4, 2, 2);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -335,7 +335,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithGitHubDocs()
     {
-        $this->setMocks(4, 2, 1);
+        $this->setMocks(4, 2);
         $this->filesystem->shouldReceive('put')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -352,7 +352,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationFromConfiguration()
     {
-        $this->setMocks(5, 3, 10, 10, 11);
+        $this->setMocks(5, 3, 10, 9, 11);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -378,7 +378,7 @@ class ConstructCommandTest extends PHPUnit
      */
     public function testProjectGenerationFromConfigurationWithInvalidSettings()
     {
-        $this->setMocks(4, 3, 10, 11, 11);
+        $this->setMocks(4, 3, 10, 10, 11);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -445,7 +445,7 @@ class ConstructCommandTest extends PHPUnit
      * @param int $getTimes
      * @param int $putTimes
      */
-    protected function setMocks($makeDirectoryTimes = 3, $isDirectoryTimes = 1, $copyTimes = 1, $getTimes = 10, $putTimes = 10)
+    protected function setMocks($makeDirectoryTimes = 3, $isDirectoryTimes = 1, $copyTimes = 0, $getTimes = 10, $putTimes = 11)
     {
         $this->filesystem->shouldReceive('makeDirectory')->times($makeDirectoryTimes)->andReturnNull();
         $this->filesystem->shouldReceive('isDirectory')->times($isDirectoryTimes)->andReturnNull();

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -180,6 +180,7 @@ class ConstructTest extends PHPUnit
         $this->assertSame($this->getStub('composer.phpspec'), $this->getFile('composer.json'));
         $this->assertSame($this->getStub('gitattributes.phpspec'), $this->getFile('.gitattributes'));
         $this->assertTrue(is_dir(__DIR__ . '/../logger/specs'));
+        $this->assertSame($this->getStub('gitignore.phpspec'), $this->getFile('.gitignore'));
     }
 
     public function testProjectGenerationWithApacheLicense()

--- a/tests/stubs/gitignore.phpspec.stub
+++ b/tests/stubs/gitignore.phpspec.stub
@@ -1,4 +1,3 @@
-.env
 /vendor
 composer.lock
-phpunit.xml
+phpspec.yml

--- a/tests/stubs/gitignore.stub
+++ b/tests/stubs/gitignore.stub
@@ -1,3 +1,3 @@
-# composer
-/vendor/
+/vendor
+composer.lock
 phpunit.xml


### PR DESCRIPTION
- Patterns are gathered similar to the `export-ignore` entries of
  the .gitattributes file
- The non `dist` test or spec configuration is ignored
