### PR TITLE
Add ability to configure Git commit message template. Closes #144.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### v1.12.0 `2016-09-??`
+- `Added`
+    - A generated `.gitmessage` template and a Composer script for it's configuration _can_ be used to improve the commit message quality and consistency. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#144](https://github.com/jonathantorres/construct/issues/144).
+
 #### v1.11.0 `2016-09-10`
 - `Added`
     - User can use the `github` alias implicating all `--github-*` options. Done by [@raphaelstolt](https://github.com/raphaelstolt).

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The generated project structure will look like the following `tree` excerpt. Fil
 │   │   ├── ISSUE_TEMPLATE.md
 │   │   └── PULL_REQUEST_TEMPLATE.md
 │   ├── .gitignore
+│   ├── .gitmessage
 │   ├── (.lgtm)
 │   ├── LICENSE.md
 │   ├── (MAINTAINERS)

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -161,6 +161,7 @@ class Construct
         $this->composer($git);
         $this->projectClass();
         $this->gitignore();
+        $this->gitmessage();
         $this->gitattributes();
 
         if ($this->settings->withGitInit()) {
@@ -270,11 +271,14 @@ class Construct
             $contributing = $this->file->get(__DIR__ . '/stubs/CONTRIBUTING.stub');
         }
 
-        $content = str_replace(
-            '{project_lower}',
-            $this->projectLower,
-            $contributing
-        );
+        $placeholder = ['{project_lower}', '{git_message_path}'];
+        $replacements = [$this->projectLower, '.gitmessage'];
+
+        if ($this->settings->withGithubTemplates()) {
+            $replacements = [$this->projectLower, '../.gitmessage'];
+        }
+
+        $content = str_replace($placeholder, $replacements, $contributing);
 
         $this->file->put($this->projectLower . '/' . 'CONTRIBUTING.md', $content);
         $this->exportIgnores[] = 'CONTRIBUTING.md';
@@ -522,6 +526,22 @@ class Construct
 
         $this->file->put($this->projectLower . '/' . '.gitattributes', $content);
     }
+
+    /**
+     * Copy .gitmessage stub file.
+     *
+     * @return void
+     */
+    protected function gitmessage()
+    {
+        $this->file->put(
+            $this->projectLower . '/' . '.gitmessage',
+            $this->file->get(__DIR__ . '/stubs/gitmessage.stub')
+        );
+
+        $this->exportIgnores[] = '.gitmessage';
+    }
+
 
     /**
      * Do an initial composer install and require the set development packages

--- a/src/stubs/CONTRIBUTING.PHPCS.stub
+++ b/src/stubs/CONTRIBUTING.PHPCS.stub
@@ -6,3 +6,5 @@ Thanks for contributing to {project_lower}! Just follow these single guidelines:
 - Ensure the coding standard compliance before committing or opening pull requests by running `composer cs-fix` in the root directory of this repository.
 
 - You __MUST__ use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.
+
+- You __MUST__ use the provided [commit message template]({git_message_path}), which follows the [rules](http://chris.beams.io/posts/git-commit/) described by Chris Beams. It can be configured via `composer configure-commit-template` prior to committing.

--- a/src/stubs/CONTRIBUTING.stub
+++ b/src/stubs/CONTRIBUTING.stub
@@ -4,3 +4,5 @@ Thanks for contributing to {project_lower}! Just follow these single guidelines:
 - You __MUST__ follow the PSR-2 coding standard. More info [here](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).
 
 - You __MUST__ use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.
+
+- You __MUST__ use the provided [commit message template]({git_message_path}), which follows the [rules](http://chris.beams.io/posts/git-commit/) described by Chris Beams. It can be configured via `composer configure-commit-template` prior to committing.

--- a/src/stubs/composer/composer.behat.stub
+++ b/src/stubs/composer/composer.behat.stub
@@ -19,6 +19,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "{testing}"
+        "test": "{testing}",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/src/stubs/composer/composer.codeception.stub
+++ b/src/stubs/composer/composer.codeception.stub
@@ -19,6 +19,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "codecept run"
+        "test": "codecept run",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/src/stubs/composer/composer.phpspec.stub
+++ b/src/stubs/composer/composer.phpspec.stub
@@ -19,6 +19,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "{testing} run --format=pretty"
+        "test": "{testing} run --format=pretty",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/src/stubs/composer/composer.phpunit.stub
+++ b/src/stubs/composer/composer.phpunit.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "{testing}"
+        "test": "{testing}",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/src/stubs/gitmessage.stub
+++ b/src/stubs/gitmessage.stub
@@ -1,0 +1,11 @@
+Subject line
+
+# - Capitalise the subject line and do not end it with a period
+# - Use the imperative mood in the subject line
+# - Summarise changes in around 50 (soft limit, hard limit at 69)
+#   characters or less in the subject line
+# - Separate subject line from body with a blank line
+Optional subject body
+# - Capitalise the subject body
+# - Use the subject body to explain what and why vs. how
+# - Wrap the subject body at 72 characters

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -31,7 +31,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGeneration()
     {
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 2, 0, 11);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -112,7 +112,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithASpecifiedTestingFramework()
     {
-        $this->setMocks(2, 2, 0, 8, 9);
+        $this->setMocks(2, 2, 0, 9, 10);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -129,7 +129,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithASpecifiedTestingFrameworkViaAlias()
     {
-        $this->setMocks(2, 2, 0, 8, 9);
+        $this->setMocks(2, 2, 0, 9, 10);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -302,7 +302,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithEnvironmentFiles()
     {
-        $this->setMocks(3, 2, 2, 10, 11);
+        $this->setMocks(3, 2, 2);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -352,7 +352,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationFromConfiguration()
     {
-        $this->setMocks(5, 3, 10, 9, 11);
+        $this->setMocks(5, 3, 10, 10);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -375,7 +375,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithGitHubAlias()
     {
-        $this->setMocks(5, 3, 10, 9, 11);
+        $this->setMocks(5, 3, 10, 10);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -401,7 +401,7 @@ class ConstructCommandTest extends PHPUnit
      */
     public function testProjectGenerationFromConfigurationWithInvalidSettings()
     {
-        $this->setMocks(4, 3, 10, 10, 11);
+        $this->setMocks(4, 3, 10, 11);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -468,7 +468,7 @@ class ConstructCommandTest extends PHPUnit
      * @param int $getTimes
      * @param int $putTimes
      */
-    protected function setMocks($makeDirectoryTimes = 3, $isDirectoryTimes = 1, $copyTimes = 0, $getTimes = 10, $putTimes = 11)
+    protected function setMocks($makeDirectoryTimes = 3, $isDirectoryTimes = 1, $copyTimes = 0, $getTimes = 11, $putTimes = 12)
     {
         $this->filesystem->shouldReceive('makeDirectory')->times($makeDirectoryTimes)->andReturnNull();
         $this->filesystem->shouldReceive('isDirectory')->times($isDirectoryTimes)->andReturnNull();

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -102,6 +102,7 @@ class ConstructTest extends PHPUnit
         $this->assertSame($this->getStub('travis'), $this->getFile('.travis.yml'));
         $this->assertSame($this->getStub('gitignore'), $this->getFile('.gitignore'));
         $this->assertSame($this->getStub('gitattributes'), $this->getFile('.gitattributes'));
+        $this->assertSame($this->getStub('gitmessage'), $this->getFile('.gitmessage'));
         $this->assertSame($this->getStub('Logger'), $this->getFile('src/Logger.php'));
         $this->assertSame($this->getStub('LoggerTest'), $this->getFile('tests/LoggerTest.php'));
     }
@@ -594,6 +595,10 @@ class ConstructTest extends PHPUnit
         $this->assertSame(
             $this->getStub('with-github-templates/README'),
             $this->getFile('README.md')
+        );
+        $this->assertSame(
+            $this->getStub('with-github-templates/CONTRIBUTING'),
+            $this->getFile('.github/CONTRIBUTING.md')
         );
     }
 

--- a/tests/stubs/composer.behat.stub
+++ b/tests/stubs/composer.behat.stub
@@ -19,6 +19,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "behat"
+        "test": "behat",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.codeception.stub
+++ b/tests/stubs/composer.codeception.stub
@@ -19,6 +19,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "codecept run"
+        "test": "codecept run",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.keywords.stub
+++ b/tests/stubs/composer.keywords.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.php54.stub
+++ b/tests/stubs/composer.php54.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.php55.stub
+++ b/tests/stubs/composer.php55.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.php56.stub
+++ b/tests/stubs/composer.php56.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.php7.stub
+++ b/tests/stubs/composer.php7.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.phpspec.stub
+++ b/tests/stubs/composer.phpspec.stub
@@ -19,6 +19,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpspec run --format=pretty"
+        "test": "phpspec run --format=pretty",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/composer.stub
+++ b/tests/stubs/composer.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/gitattributes.phpspec.stub
+++ b/tests/stubs/gitattributes.phpspec.stub
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore

--- a/tests/stubs/gitattributes.stub
+++ b/tests/stubs/gitattributes.stub
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore

--- a/tests/stubs/gitmessage.stub
+++ b/tests/stubs/gitmessage.stub
@@ -1,0 +1,11 @@
+Subject line
+
+# - Capitalise the subject line and do not end it with a period
+# - Use the imperative mood in the subject line
+# - Summarise changes in around 50 (soft limit, hard limit at 69)
+#   characters or less in the subject line
+# - Separate subject line from body with a blank line
+Optional subject body
+# - Capitalise the subject body
+# - Use the subject body to explain what and why vs. how
+# - Wrap the subject body at 72 characters

--- a/tests/stubs/with-code-of-conduct/gitattributes.stub
+++ b/tests/stubs/with-code-of-conduct/gitattributes.stub
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 CONDUCT.md export-ignore

--- a/tests/stubs/with-editorconfig/gitattributes.stub
+++ b/tests/stubs/with-editorconfig/gitattributes.stub
@@ -3,6 +3,7 @@
 .editorconfig export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore

--- a/tests/stubs/with-env/composer.stub
+++ b/tests/stubs/with-env/composer.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/with-env/gitattributes.stub
+++ b/tests/stubs/with-env/gitattributes.stub
@@ -3,6 +3,7 @@
 .env export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore

--- a/tests/stubs/with-github-docs/gitattributes.stub
+++ b/tests/stubs/with-github-docs/gitattributes.stub
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore

--- a/tests/stubs/with-github-templates/CONTRIBUTING.stub
+++ b/tests/stubs/with-github-templates/CONTRIBUTING.stub
@@ -5,4 +5,4 @@ Thanks for contributing to logger! Just follow these single guidelines:
 
 - You __MUST__ use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.
 
-- You __MUST__ use the provided [commit message template](.gitmessage), which follows the [rules](http://chris.beams.io/posts/git-commit/) described by Chris Beams. It can be configured via `composer configure-commit-template` prior to committing.
+- You __MUST__ use the provided [commit message template](../.gitmessage), which follows the [rules](http://chris.beams.io/posts/git-commit/) described by Chris Beams. It can be configured via `composer configure-commit-template` prior to committing.

--- a/tests/stubs/with-github-templates/gitattributes.stub
+++ b/tests/stubs/with-github-templates/gitattributes.stub
@@ -3,6 +3,7 @@
 .gitattributes export-ignore
 .github/ export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 LICENSE.md export-ignore

--- a/tests/stubs/with-lgtm/gitattributes.stub
+++ b/tests/stubs/with-lgtm/gitattributes.stub
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .lgtm export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore

--- a/tests/stubs/with-namespace/composer.stub
+++ b/tests/stubs/with-namespace/composer.stub
@@ -24,6 +24,7 @@
     },
     "minimum-stability": "stable",
     "scripts": {
-        "test": "phpunit"
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
     }
 }

--- a/tests/stubs/with-phpcs/CONTRIBUTING.stub
+++ b/tests/stubs/with-phpcs/CONTRIBUTING.stub
@@ -6,3 +6,5 @@ Thanks for contributing to logger! Just follow these single guidelines:
 - Ensure the coding standard compliance before committing or opening pull requests by running `composer cs-fix` in the root directory of this repository.
 
 - You __MUST__ use [feature / topic branches](https://git-scm.com/book/en/v2/Git-Branching-Branching-Workflows) to ease the merge of contributions.
+
+- You __MUST__ use the provided [commit message template](.gitmessage), which follows the [rules](http://chris.beams.io/posts/git-commit/) described by Chris Beams. It can be configured via `composer configure-commit-template` prior to committing.

--- a/tests/stubs/with-phpcs/composer.stub
+++ b/tests/stubs/with-phpcs/composer.stub
@@ -25,6 +25,7 @@
     "minimum-stability": "stable",
     "scripts": {
         "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage",
         "cs-fix": "php-cs-fixer fix . -vv || true"
     }
 }

--- a/tests/stubs/with-phpcs/gitattributes.stub
+++ b/tests/stubs/with-phpcs/gitattributes.stub
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .php_cs export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore

--- a/tests/stubs/with-vagrant/gitattributes.stub
+++ b/tests/stubs/with-vagrant/gitattributes.stub
@@ -2,6 +2,7 @@
 
 .gitattributes export-ignore
 .gitignore export-ignore
+.gitmessage export-ignore
 .travis.yml export-ignore
 CHANGELOG.md export-ignore
 CONTRIBUTING.md export-ignore


### PR DESCRIPTION
- A `.gitmessage` template is copied into the project's root directory
- To improve the commit message quality and consistency it can be enabled via a Composer script
