### PR TITLE
Ensure line endings on checkout.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 example/ export-ignore
 tests/ export-ignore

--- a/src/stubs/gitattributes.stub
+++ b/src/stubs/gitattributes.stub
@@ -1,1 +1,1 @@
-* text=auto
+* text=auto eol=lf

--- a/tests/stubs/gitattributes.phpspec.stub
+++ b/tests/stubs/gitattributes.phpspec.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/tests/stubs/gitattributes.stub
+++ b/tests/stubs/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/tests/stubs/with-code-of-conduct/gitattributes.stub
+++ b/tests/stubs/with-code-of-conduct/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/tests/stubs/with-editorconfig/gitattributes.stub
+++ b/tests/stubs/with-editorconfig/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .editorconfig export-ignore
 .gitattributes export-ignore

--- a/tests/stubs/with-env/gitattributes.stub
+++ b/tests/stubs/with-env/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .env export-ignore
 .gitattributes export-ignore

--- a/tests/stubs/with-github-docs/gitattributes.stub
+++ b/tests/stubs/with-github-docs/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/tests/stubs/with-github-templates/gitattributes.stub
+++ b/tests/stubs/with-github-templates/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .github/ export-ignore

--- a/tests/stubs/with-lgtm/gitattributes.stub
+++ b/tests/stubs/with-lgtm/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/tests/stubs/with-phpcs/gitattributes.stub
+++ b/tests/stubs/with-phpcs/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/tests/stubs/with-vagrant/gitattributes.stub
+++ b/tests/stubs/with-vagrant/gitattributes.stub
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .gitattributes export-ignore
 .gitignore export-ignore


### PR DESCRIPTION
Avoid different line endings on Git checkouts and related warnings in PHPUnit assertions.
