### PR TITLE
Avoid flickering tests.

### DIFF
--- a/src/Construct.php
+++ b/src/Construct.php
@@ -519,10 +519,10 @@ class Construct
         $content = $this->file->get(__DIR__ . '/stubs/gitattributes.stub');
 
         foreach ($this->exportIgnores as $ignore) {
-            $content .= PHP_EOL . $ignore . ' export-ignore';
+            $content .= "\n" . $ignore . ' export-ignore';
         }
 
-        $content .= PHP_EOL;
+        $content .= "\n";
 
         $this->file->put($this->projectLower . '/' . '.gitattributes', $content);
     }


### PR DESCRIPTION
By using a fix line ending and not a platform given one `assertSame` assertions don't fail on Windows systems.
