### PR TITLE
Enforce coding standards.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # composer
 /vendor/
+
+# PHP Coding Standards Fixer
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -6,6 +6,7 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
 
 return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
+    ->setUsingCache(true)
     ->fixers(array(
         '-psr0',
         'short_array_syntax',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### v1.13.0 `2016-10-??`
+- `Added`
+    - Coding standard checks based on the PHP Coding Standards Fixer are cached and validated via a Travis CI script. Done by [@raphaelstolt](https://github.com/raphaelstolt) and initiated by [@localheinz](https://github.com/localheinz).
+
 #### v1.12.0 `2016-09-18`
 - `Added`
     - A generated `.gitmessage` template and a Composer script for it's configuration _can_ be used to improve the commit message quality and consistency. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#144](https://github.com/jonathantorres/construct/issues/144).

--- a/README.md
+++ b/README.md
@@ -138,8 +138,7 @@ construct generate jonathantorres/logger -g
 ```
 
 ## Generate a PHP Coding Standards Fixer configuration?
-The `--phpcs` option will generate a [PHP Coding Standards Fixer](http://cs.sensiolabs.org/) configuration
-within the constructed project. The generated `.php_cs` configuration defaults to the `PSR-2` coding style guide.
+The `--phpcs` option will generate a [PHP Coding Standards Fixer](http://cs.sensiolabs.org/) configuration within the constructed project and add a Travis CI script for validation during builds. The generated `.php_cs` configuration defaults to the `PSR-2` coding style guide.
 
 ```bash
 construct generate jonathantorres/logger --phpcs

--- a/src/Commands/ConstructCommand.php
+++ b/src/Commands/ConstructCommand.php
@@ -216,12 +216,11 @@ class ConstructCommand extends Command
         $output->writeln('<info>Project "' . $projectName . '" constructed.</info>');
     }
 
-
     /**
      * Shows warnings and sets a new settings which overwrites
      * invalid settings with default values.
      *
-     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     * @param  \Symfony\Component\Console\Output\OutputInterface $output
      * @return void
      */
     private function warnAndOverwriteInvalidSettingsWithDefaults($output)
@@ -250,7 +249,6 @@ class ConstructCommand extends Command
             $this->settings->withGithubDocs()
         );
     }
-
 
     /**
      * Determine if a configuration is applicable.

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -548,7 +548,6 @@ class Construct
         $this->exportIgnores[] = '.gitmessage';
     }
 
-
     /**
      * Do an initial composer install and require the set development packages
      * in the constructed project.

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -329,6 +329,7 @@ class Construct
             $this->projectLower . '/' . '.php_cs'
         );
 
+        $this->gitIgnores[] = '.php_cs.cache';
         $this->exportIgnores[] = '.php_cs';
     }
 
@@ -339,7 +340,12 @@ class Construct
      */
     protected function travis()
     {
-        $file = $this->file->get(__DIR__ . '/stubs/travis.stub');
+        if ($this->settings->withPhpcsConfiguration()) {
+            $file = $this->file->get(__DIR__ . '/stubs/travis.phpcs.stub');
+        } else {
+            $file = $this->file->get(__DIR__ . '/stubs/travis.stub');
+        }
+
         $travisHelper = new Travis();
         $phpVersionsToRunOnTravis = $travisHelper->phpVersionsToRun(
             $travisHelper->phpVersionsToTest($this->settings->getPhpVersion())

--- a/src/stubs/phpcs.stub
+++ b/src/stubs/phpcs.stub
@@ -6,4 +6,5 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
 return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ->fixers(array('-psr0'))
-    ->finder($finder);
+    ->finder($finder)
+    ->setUsingCache(true);

--- a/src/stubs/travis.phpcs.stub
+++ b/src/stubs/travis.phpcs.stub
@@ -1,20 +1,12 @@
 language: php
 
 php:
-  - hhvm
-  - nightly
-  - 7
-  - 5.6
-  - 5.5
-  - 5.4
-
-matrix:
-  fast_finish: true
+{phpVersions}
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
-  - composer self-update
-  - composer install -n
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction
 
 script:
   - vendor/bin/php-cs-fixer fix --diff --verbose --dry-run

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -332,6 +332,7 @@ class ConstructTest extends PHPUnit
 
         $this->assertSame($this->getStub('with-phpcs/phpcs'), $this->getFile('.php_cs'));
         $this->assertSame($this->getStub('with-phpcs/gitattributes'), $this->getFile('.gitattributes'));
+        $this->assertSame($this->getStub('with-phpcs/travis'), $this->getFile('.travis.yml'));
         $this->assertSame(
             $this->getStub('with-phpcs/CONTRIBUTING'),
             $this->getFile('CONTRIBUTING.md')

--- a/tests/stubs/with-phpcs/phpcs.stub
+++ b/tests/stubs/with-phpcs/phpcs.stub
@@ -6,4 +6,5 @@ $finder = Symfony\CS\Finder\DefaultFinder::create()
 return Symfony\CS\Config\Config::create()
     ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
     ->fixers(array('-psr0'))
-    ->finder($finder);
+    ->finder($finder)
+    ->setUsingCache(true);

--- a/tests/stubs/with-phpcs/travis.stub
+++ b/tests/stubs/with-phpcs/travis.stub
@@ -3,18 +3,13 @@ language: php
 php:
   - hhvm
   - nightly
-  - 7
   - 5.6
-  - 5.5
-  - 5.4
-
-matrix:
-  fast_finish: true
+  - 7.0
 
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
-  - composer self-update
-  - composer install -n
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction
 
 script:
   - vendor/bin/php-cs-fixer fix --diff --verbose --dry-run


### PR DESCRIPTION
Adds a local php-cs-fixer cache and validation during Travis CI builds.
