### PR TITLE
Sort Composer dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### v1.13.0 `2016-10-??`
 - `Added`
     - Coding standard checks based on the PHP Coding Standards Fixer are cached and validated via a Travis CI script. Done by [@raphaelstolt](https://github.com/raphaelstolt) and initiated by [@localheinz](https://github.com/localheinz).
+    - Composer dependencies are sorted. Done by [@raphaelstolt](https://github.com/raphaelstolt).
 
 #### v1.12.0 `2016-09-18`
 - `Added`

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
         "symfony/yaml": "^2.6 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8 || ^5.0",
+        "friendsofphp/php-cs-fixer": "^1.11",
         "mockery/mockery": "0.9.*",
-        "friendsofphp/php-cs-fixer": "^1.11"
+        "phpunit/phpunit": "^4.8 || ^5.0"
     },
     "autoload": {
         "psr-4": {
@@ -32,7 +32,8 @@
     "config": {
         "platform": {
             "php": "5.4"
-        }
+        },
+        "sort-packages": true
     },
     "bin": ["construct"],
     "scripts": {

--- a/src/stubs/composer/composer.behat.stub
+++ b/src/stubs/composer/composer.behat.stub
@@ -18,6 +18,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "{testing}",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/src/stubs/composer/composer.codeception.stub
+++ b/src/stubs/composer/composer.codeception.stub
@@ -18,6 +18,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "codecept run",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/src/stubs/composer/composer.phpspec.stub
+++ b/src/stubs/composer/composer.phpspec.stub
@@ -18,6 +18,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "{testing} run --format=pretty",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/src/stubs/composer/composer.phpunit.stub
+++ b/src/stubs/composer/composer.phpunit.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "{testing}",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.behat.stub
+++ b/tests/stubs/composer.behat.stub
@@ -18,6 +18,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "behat",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.codeception.stub
+++ b/tests/stubs/composer.codeception.stub
@@ -18,6 +18,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "codecept run",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.keywords.stub
+++ b/tests/stubs/composer.keywords.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.php54.stub
+++ b/tests/stubs/composer.php54.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.php55.stub
+++ b/tests/stubs/composer.php55.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.php56.stub
+++ b/tests/stubs/composer.php56.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.php7.stub
+++ b/tests/stubs/composer.php7.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.phpspec.stub
+++ b/tests/stubs/composer.phpspec.stub
@@ -18,6 +18,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpspec run --format=pretty",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/composer.stub
+++ b/tests/stubs/composer.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/with-env/composer.stub
+++ b/tests/stubs/with-env/composer.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/with-namespace/composer.stub
+++ b/tests/stubs/with-namespace/composer.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage"

--- a/tests/stubs/with-phpcs/composer.stub
+++ b/tests/stubs/with-phpcs/composer.stub
@@ -23,6 +23,9 @@
         }
     },
     "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
     "scripts": {
         "test": "phpunit",
         "configure-commit-template": "git config --add commit.template .gitmessage",


### PR DESCRIPTION
Enables sorting of Composer dependencies when added via `composer require vendor/package` or  `composer require --dev vendor/package`.
