### PR TITLE
Add PHP 7.1 to Travis CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
 language: php
 
-php:
-  - hhvm
-  - nightly
-  - 7
-  - 5.6
-  - 5.5
-  - 5.4
+env:
+  global:
+    - disable-xdebug=true
 
 matrix:
+  include:
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: nightly
+      env: disable-xdebug=false
+    - php: 7.1
+      env: disable-xdebug=false
+    - php: 7.0
+    - php: 5.6
+    - php: 5.5
+    - php: 5.4
   fast_finish: true
 
 cache:
@@ -17,7 +24,9 @@ cache:
     - $HOME/.php-cs-fixer
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - composer self-update
   - composer install -n
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### v1.13.0 `2016-10-??`
 - `Added`
+    - PHP version `7.1` is added to Travis CI builds. Done by [@raphaelstolt](https://github.com/raphaelstolt).
     - Coding standard checks based on the PHP Coding Standards Fixer are cached and validated via a Travis CI script. Done by [@raphaelstolt](https://github.com/raphaelstolt) and initiated by [@localheinz](https://github.com/localheinz).
     - Composer dependencies are sorted. Done by [@raphaelstolt](https://github.com/raphaelstolt).
     - Composer dependencies are cached for Travis CI builds. Done by [@raphaelstolt](https://github.com/raphaelstolt).

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -23,7 +23,7 @@ class Defaults
      *
      * @var array
      */
-    public $phpVersions = ['5.4', '5.5', '5.6', '7.0'];
+    public $phpVersions = ['5.4', '5.5', '5.6', '7.0', '7.1'];
 
     const TEST_FRAMEWORK = 'phpunit';
     const LICENSE = 'MIT';

--- a/src/Helpers/Travis.php
+++ b/src/Helpers/Travis.php
@@ -51,10 +51,17 @@ class Travis
      */
     public function phpVersionsToRun($phpVersions)
     {
+        $versionsWithoutXdebugExtension = ['hhvm', 'nightly', '7.1'];
         $runOn = '';
 
         for ($i = 0; $i < count($phpVersions); $i++) {
-            $runOn .= '  - ' . $phpVersions[$i];
+            if (count($i) !== 0) {
+                $runOn .= '    ';
+            }
+            $runOn .= '- php: ' . $phpVersions[$i];
+            if (in_array($phpVersions[$i], $versionsWithoutXdebugExtension)) {
+                $runOn .= "\n      env: disable-xdebug=false";
+            }
 
             if ($i !== (count($phpVersions) - 1)) {
                 $runOn .= PHP_EOL;

--- a/src/stubs/travis.phpcs.stub
+++ b/src/stubs/travis.phpcs.stub
@@ -1,14 +1,22 @@
 language: php
 
-php:
+env:
+  global:
+    - disable-xdebug=true
+
+matrix:
+  include:
 {phpVersions}
+  fast_finish: true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/src/stubs/travis.stub
+++ b/src/stubs/travis.stub
@@ -1,14 +1,22 @@
 language: php
 
-php:
+env:
+  global:
+    - disable-xdebug=true
+
+matrix:
+  include:
 {phpVersions}
+  fast_finish: true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -506,6 +506,30 @@ class ConstructTest extends PHPUnit
         $this->assertSame($this->getStub('travis.php7'), $this->getFile('.travis.yml'));
     }
 
+    public function testProjectGenerationWithPhp71()
+    {
+        $settings = new Settings(
+            'jonathantorres/logger',
+            'phpunit',
+            'MIT',
+            'Vendor\Project',
+            null,
+            null,
+            null,
+            null,
+            null,
+            '7.1.2',
+            null,
+            null
+        );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
+        $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
+        $this->assertSame($this->getStub('composer.php71'), $this->getFile('composer.json'));
+        $this->assertSame($this->getStub('travis.php71'), $this->getFile('.travis.yml'));
+    }
+
     public function testProjectGenerationWithEnvironmentFiles()
     {
         $settings = new Settings(

--- a/tests/Helpers/TravisTest.php
+++ b/tests/Helpers/TravisTest.php
@@ -25,6 +25,7 @@ class TravisTest extends PHPUnit
             '5.5',
             '5.6',
             '7.0',
+            '7.1',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -43,14 +44,22 @@ class TravisTest extends PHPUnit
             '5.5.9',
             '5.6',
             '7.0',
+            '7.1',
         ]);
-        $stringExpected = '  - hhvm' . PHP_EOL .
-                          '  - nightly' . PHP_EOL .
-                          '  - 5.4' . PHP_EOL .
-                          '  - 5.5' . PHP_EOL .
-                          '  - 5.5.9' . PHP_EOL .
-                          '  - 5.6' . PHP_EOL .
-                          '  - 7.0';
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: nightly
+      env: disable-xdebug=false
+    - php: 5.4
+    - php: 5.5
+    - php: 5.5.9
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
     }
@@ -67,6 +76,7 @@ class TravisTest extends PHPUnit
             '5.5',
             '5.6',
             '7.0',
+            '7.1',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -83,12 +93,19 @@ class TravisTest extends PHPUnit
             '5.5.9',
             '5.6',
             '7.0',
+            '7.1',
         ]);
-        $stringExpected = '  - hhvm' . PHP_EOL .
-                          '  - 5.5' . PHP_EOL .
-                          '  - 5.5.9' . PHP_EOL .
-                          '  - 5.6' . PHP_EOL .
-                          '  - 7.0';
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: 5.5
+    - php: 5.5.9
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
     }
@@ -105,6 +122,7 @@ class TravisTest extends PHPUnit
             '5.5',
             '5.6',
             '7.0',
+            '7.1',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -120,11 +138,18 @@ class TravisTest extends PHPUnit
             '5.5.9',
             '5.6',
             '7.0',
+            '7.1',
         ]);
-        $stringExpected = '  - hhvm' . PHP_EOL .
-                          '  - 5.5.9' . PHP_EOL .
-                          '  - 5.6' . PHP_EOL .
-                          '  - 7.0';
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: 5.5.9
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
     }
@@ -140,6 +165,7 @@ class TravisTest extends PHPUnit
             'nightly',
             '5.6',
             '7.0',
+            '7.1',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -154,10 +180,17 @@ class TravisTest extends PHPUnit
             'hhvm',
             '5.6',
             '7.0',
+            '7.1',
         ]);
-        $stringExpected = '  - hhvm' . PHP_EOL .
-                          '  - 5.6' . PHP_EOL .
-                          '  - 7.0';
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
     }
@@ -174,6 +207,7 @@ class TravisTest extends PHPUnit
             'nightly',
             '5.6',
             '7.0',
+            '7.1',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -182,13 +216,14 @@ class TravisTest extends PHPUnit
     /**
      * @test
      */
-    public function it_should_return_all_versions_to_test_on_a_php7_project()
+    public function it_should_return_all_versions_to_test_on_a_php7_0_project()
     {
         $versionsToTest = $this->travis->phpVersionsToTest('7.0.0');
         $versionsExpected = [
             'hhvm',
             'nightly',
             '7.0',
+            '7.1',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -197,14 +232,56 @@ class TravisTest extends PHPUnit
     /**
      * @test
      */
-    public function it_should_generate_string_of_all_versions_to_run_on_a_php7_project()
+    public function it_should_generate_string_of_all_versions_to_run_on_a_php7_0_project()
     {
         $versionsToRun = $this->travis->phpVersionsToRun([
             'hhvm',
             '7.0',
+            '7.1',
         ]);
-        $stringExpected = '  - hhvm' . PHP_EOL .
-                          '  - 7.0';
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+CONTENT;
+
+        $this->assertEquals($versionsToRun, $stringExpected);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_return_all_versions_to_test_on_a_php7_1_project()
+    {
+        $versionsToTest = $this->travis->phpVersionsToTest('7.1.0');
+        $versionsExpected = [
+            'hhvm',
+            'nightly',
+            '7.1',
+        ];
+
+        $this->assertEquals($versionsToTest, $versionsExpected);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_string_of_all_versions_to_run_on_a_php7_1_project()
+    {
+        $versionsToRun = $this->travis->phpVersionsToRun([
+            'hhvm',
+            '7.1',
+        ]);
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: 7.1
+      env: disable-xdebug=false
+CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
     }

--- a/tests/stubs/composer.php71.stub
+++ b/tests/stubs/composer.php71.stub
@@ -1,0 +1,33 @@
+{
+    "name": "jonathantorres/logger",
+    "description": "PHP project.",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jonathan Torres",
+            "email": "jonathantorres41@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=7.1.2"
+    },
+    "autoload": {
+        "psr-4": {
+            "Jonathantorres\\Logger\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Jonathantorres\\Logger\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
+    }
+}

--- a/tests/stubs/travis.php54.stub
+++ b/tests/stubs/travis.php54.stub
@@ -1,19 +1,31 @@
 language: php
 
-php:
-  - hhvm
-  - nightly
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
+env:
+  global:
+    - disable-xdebug=true
+
+matrix:
+  include:
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: nightly
+      env: disable-xdebug=false
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+  fast_finish: true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.php55.stub
+++ b/tests/stubs/travis.php55.stub
@@ -1,18 +1,30 @@
 language: php
 
-php:
-  - hhvm
-  - nightly
-  - 5.5
-  - 5.6
-  - 7.0
+env:
+  global:
+    - disable-xdebug=true
+
+matrix:
+  include:
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: nightly
+      env: disable-xdebug=false
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+  fast_finish: true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.php7.stub
+++ b/tests/stubs/travis.php7.stub
@@ -1,16 +1,28 @@
 language: php
 
-php:
-  - hhvm
-  - nightly
-  - 7.0
+env:
+  global:
+    - disable-xdebug=true
+
+matrix:
+  include:
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: nightly
+      env: disable-xdebug=false
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+  fast_finish: true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/travis.php71.stub
+++ b/tests/stubs/travis.php71.stub
@@ -10,8 +10,6 @@ matrix:
       env: disable-xdebug=false
     - php: nightly
       env: disable-xdebug=false
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
       env: disable-xdebug=false
   fast_finish: true

--- a/tests/stubs/travis.stub
+++ b/tests/stubs/travis.stub
@@ -1,17 +1,29 @@
 language: php
 
-php:
-  - hhvm
-  - nightly
-  - 5.6
-  - 7.0
+env:
+  global:
+    - disable-xdebug=true
+
+matrix:
+  include:
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: nightly
+      env: disable-xdebug=false
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+  fast_finish: true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 

--- a/tests/stubs/with-phpcs/travis.stub
+++ b/tests/stubs/with-phpcs/travis.stub
@@ -1,17 +1,29 @@
 language: php
 
-php:
-  - hhvm
-  - nightly
-  - 5.6
-  - 7.0
+env:
+  global:
+    - disable-xdebug=true
+
+matrix:
+  include:
+    - php: hhvm
+      env: disable-xdebug=false
+    - php: nightly
+      env: disable-xdebug=false
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: disable-xdebug=false
+  fast_finish: true
 
 cache:
   directories:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION != hhvm && $TRAVIS_PHP_VERSION != nightly ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $disable-xdebug = true ]]; then
+      phpenv config-rm xdebug.ini;
+    fi
   - travis_retry composer self-update
   - travis_retry composer install --no-interaction
 


### PR DESCRIPTION
Adds support for PHP `7.1` which required a severe refactoring of the `.travis.yml` structure.
