### PR TITLE
Align generated php-cs-fixer configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
     - Composer dependencies are sorted. Done by [@raphaelstolt](https://github.com/raphaelstolt).
     - Composer dependencies are cached for Travis CI builds. Done by [@raphaelstolt](https://github.com/raphaelstolt).
 
+- `Fixed`
+    - Aligned generated `.php_cs` configuration with `php-cs-fixer` ^2.0 release. Done by [@raphaelstolt](https://github.com/raphaelstolt).
+
 #### v1.12.0 `2016-09-18`
 - `Added`
     - A generated `.gitmessage` template and a Composer script for it's configuration _can_ be used to improve the commit message quality and consistency. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#144](https://github.com/jonathantorres/construct/issues/144).

--- a/src/stubs/phpcs.stub
+++ b/src/stubs/phpcs.stub
@@ -1,10 +1,16 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
 
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-    ->fixers(array('-psr0'))
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+
+$rules = [
+    'psr0' => false,
+    '@PSR2' => true,
+];
+
+return PhpCsFixer\Config::create()
+    ->setRules($rules)
     ->finder($finder)
-    ->setUsingCache(true);
+    ->setCacheFile($cacheDir . '/.php_cs.cache');

--- a/tests/stubs/with-phpcs/phpcs.stub
+++ b/tests/stubs/with-phpcs/phpcs.stub
@@ -1,10 +1,16 @@
 <?php
 
-$finder = Symfony\CS\Finder\DefaultFinder::create()
+$finder = PhpCsFixer\Finder::create()
     ->in(__DIR__);
 
-return Symfony\CS\Config\Config::create()
-    ->level(Symfony\CS\FixerInterface::PSR2_LEVEL)
-    ->fixers(array('-psr0'))
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+
+$rules = [
+    'psr0' => false,
+    '@PSR2' => true,
+];
+
+return PhpCsFixer\Config::create()
+    ->setRules($rules)
     ->finder($finder)
-    ->setUsingCache(true);
+    ->setCacheFile($cacheDir . '/.php_cs.cache');


### PR DESCRIPTION
Aligns the generated `.php_cs` configuration with the `php-cs-fixer` ^2.0 release.