### PR TITLE
Fix test stub for PHPUnit 6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### v1.13.1 `2017-0?-??`
 - `Fixed`
     - Fix generated PHP Coding Standards Fixer configuration. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#172](https://github.com/jonathantorres/construct/issues/172).
+    - Executable test skeleton for PHPUnit 6. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#170](https://github.com/jonathantorres/construct/issues/170).
 
 #### v1.13.0 `2016-12-11`
 - `Added`

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -474,7 +474,11 @@ class Construct
      */
     protected function phpunitTest()
     {
-        $file = $this->file->get(__DIR__ . '/stubs/ProjectTest.stub');
+        if (version_compare($this->settings->getPhpVersion(), '7.0.0') >= 0) {
+            $file = $this->file->get(__DIR__ . '/stubs/ProjectPhpUnit6Test.stub');
+        } else {
+            $file = $this->file->get(__DIR__ . '/stubs/ProjectTest.stub');
+        }
 
         $stubs = [
             '{project_upper}',

--- a/src/stubs/ProjectPhpUnit6Test.stub
+++ b/src/stubs/ProjectPhpUnit6Test.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {namespace}\Tests;
+
+use {namespace}\{project_upper};
+use PHPUnit\Framework\TestCase;
+
+class {project_upper}Test extends TestCase
+{
+    public function testExample()
+    {
+        ${project_camel_case} = new {project_upper}();
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -530,6 +530,35 @@ class ConstructTest extends PHPUnit
         $this->assertSame($this->getStub('travis.php71'), $this->getFile('.travis.yml'));
     }
 
+    /**
+     * @ticket 170 (https://github.com/jonathantorres/construct/issues/170)
+     */
+    public function testProjectGenerationWithPhpUnit6Stub()
+    {
+        $settings = new Settings(
+            'jonathantorres/logger',
+            'phpunit',
+            'MIT',
+            'Vendor\Project',
+            null,
+            null,
+            null,
+            null,
+            null,
+            '7.1.2',
+            null,
+            null
+        );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
+        $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
+        $this->assertSame(
+            $this->getStub('LoggerTestPhpUnit6'),
+            $this->getFile('tests/LoggerTest.php')
+        );
+    }
+
     public function testProjectGenerationWithEnvironmentFiles()
     {
         $settings = new Settings(

--- a/tests/stubs/LoggerTestPhpUnit6.stub
+++ b/tests/stubs/LoggerTestPhpUnit6.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Jonathantorres\Logger\Tests;
+
+use Jonathantorres\Logger\Logger;
+use PHPUnit\Framework\TestCase;
+
+class LoggerTest extends TestCase
+{
+    public function testExample()
+    {
+        $logger = new Logger();
+
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Test skeleton is executable (again) when PHP version >= 7.0.0 and therefor PHPUnit 6 is required via Composer. Fixes #170.