### PR TITLE
Fix missing php-cs-fixer Composer scripts on Windows. Fixes #183.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - With the `--cli-framework` option a CLI project can be generated. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#175](https://github.com/jonathantorres/construct/issues/175).
 - `Fixed`
     - The package `vlucas/phpdotenv` is added as a non development requirement. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#176](https://github.com/jonathantorres/construct/issues/176).
+    - Fix PHP Coding Standards Fixer Composer scripts are set on Windows. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#183](https://github.com/jonathantorres/construct/issues/183).
 
 #### v1.13.1 `2017-03-01`
 - `Fixed`

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -457,12 +457,12 @@ class Construct
 
         $content = str_replace($stubs, $values, $file);
 
-        if ($this->settings->withPhpcsConfiguration() && !$this->str->isWindows()) {
+        if ($this->settings->withPhpcsConfiguration()) {
             $composer = json_decode($content, true);
             $composer['scripts']['cs-fix'] = 'php-cs-fixer fix . -vv || true';
             $composer['scripts']['cs-lint'] = 'php-cs-fixer fix --diff --verbose --dry-run';
             $content = json_encode($composer, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
-            $content .= PHP_EOL;
+            $content .= "\n";
         }
 
         if ($this->settings->withCliFramework()) {


### PR DESCRIPTION
The PHP Coding Standards Fixer Composer scripts are also constructed on Windows systems.