### PR TITLE
Fix missing php-cs-fixer cache directory. Fixes #186.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+#### v1.14.1 `2017-04-??`
+- `Fixed`
+    - The PHP Coding Standards Fixer cache directory is present in the generated Travis CI configuration. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#186](https://github.com/jonathantorres/construct/issues/186).
+
 #### v1.14.0 `2017-03-29`
 - `Added`
     - With the `--cli-framework` option a CLI project can be generated. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#175](https://github.com/jonathantorres/construct/issues/175).

--- a/src/stubs/travis.phpcs.stub
+++ b/src/stubs/travis.phpcs.stub
@@ -11,6 +11,7 @@ matrix:
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.php-cs-fixer
 
 before_script:
   - phpenv config-rm xdebug.ini || true

--- a/tests/stubs/with-phpcs/travis.stub
+++ b/tests/stubs/with-phpcs/travis.stub
@@ -17,6 +17,7 @@ matrix:
 cache:
   directories:
     - $HOME/.composer/cache
+    - $HOME/.php-cs-fixer
 
 before_script:
   - phpenv config-rm xdebug.ini || true


### PR DESCRIPTION
The missing php-cs-fixer cache directory is present in the generated Travis CI configuration.