### PR TITLE
Fix version guard. Fixes #192.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - Make the PHP Coding Standards Fixer linting fail early to speedup builds. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#187](https://github.com/jonathantorres/construct/issues/187).
 - `Fixed`
     - The PHP Coding Standards Fixer cache directory is present in the generated Travis CI configuration. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#186](https://github.com/jonathantorres/construct/issues/186).
+    - The PHPUnit 6 test skeleton is created on PHP 7.0.* after a fix of the version guard. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#192](https://github.com/jonathantorres/construct/issues/192).
 
 #### v1.14.0 `2017-03-29`
 - `Added`

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -508,7 +508,7 @@ class Construct
      */
     protected function phpunitTest()
     {
-        if (version_compare($this->settings->getPhpVersion(), '7.0.0') >= 0) {
+        if (version_compare($this->settings->getPhpVersion(), '7.0') >= 0) {
             $file = $this->file->get(__DIR__ . '/stubs/ProjectPhpUnit6Test.stub');
         } else {
             $file = $this->file->get(__DIR__ . '/stubs/ProjectTest.stub');

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -560,6 +560,35 @@ class ConstructTest extends PHPUnit
         );
     }
 
+    /**
+     * @ticket 192 (https://github.com/jonathantorres/construct/issues/192)
+     */
+    public function testProjectGenerationWithPhpUnit6StubOnPhp70()
+    {
+        $settings = new Settings(
+            'jonathantorres/logger',
+            'phpunit',
+            'MIT',
+            'Vendor\Project',
+            null,
+            null,
+            null,
+            null,
+            null,
+            '7.0',
+            null,
+            null
+        );
+
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
+        $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
+        $this->assertSame(
+            $this->getStub('LoggerTestPhpUnit6'),
+            $this->getFile('tests/LoggerTest.php')
+        );
+    }
+
     public function testProjectGenerationWithEnvironmentFiles()
     {
         $settings = new Settings(


### PR DESCRIPTION
Aligned the version_compare with constructs internal PHP versions.