### PR TITLE
Generate initial AppVeyor configuration. Closes #196.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-#### v1.14.2 `2017-04-??`
+#### v1.15.0 `2017-04-??`
+- `Added`
+    - Generate initial AppVeyor configuration for CLI projects. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#196](https://github.com/jonathantorres/construct/issues/196).
 - `Fixed`
     - The Xdebug extension disabling has been removed from the Travis CI configuration as Composer takes care of this since 1.3. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#194](https://github.com/jonathantorres/construct/issues/194).
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The generated project structure will look like the following `tree` excerpt. Fil
 │   ├── composer.json
 │   ├── composer.lock
 │   ├── CONTRIBUTING.md
+│   ├── (.appveyor.yml)
 │   ├── (.editorconfig)
 │   ├── (.env)
 │   ├── (.env.example)
@@ -108,7 +109,7 @@ construct generate jonathantorres/logger -s JonathanTorres\\Projects\\Logger
 ```
 
 ## Specify a CLI framework
-The optional `--cli-framework` option will allow you to specify a CLI framework for the project to construct, while also creating a bin directory with an initial CLI script in it and adding a bin key in the project's composer.json. When the option has been set without a CLI composer package the `symfony/console` package will be used per default. There's no short option available.
+The optional `--cli-framework` option will allow you to specify a CLI framework for the project to construct, while also creating a bin directory with an initial CLI script in it, adding a bin key in the project's composer.json, and an initial [AppVeyor](https://www.appveyor.com) configuration. When the option has been set without a CLI composer package the `symfony/console` package will be used per default. There's no short option available.
 
 ```bash
 construct generate jonathantorres/logger --cli-framework=zendframework/zend-console

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -231,6 +231,18 @@ class Construct
             $this->projectLower . '/bin/cli-script'
         );
 
+        $appveyorConfiguration = $this->file->get(
+            __DIR__ . '/stubs/appveyor.stub'
+        );
+
+        $minorPhpVersion = $this->str->toMinorVersion($this->settings->getPhpVersion());
+
+        $phpDownloadFile = (new Defaults())->phpAppVeyorVersions[$minorPhpVersion];
+
+        $content = str_replace('{php_download_file}', $phpDownloadFile, $appveyorConfiguration);
+        $this->file->put($this->projectLower . '/' . '.appveyor.yml', $content);
+        $this->exportIgnores[] = '.appveyor.yml';
+
         $this->requirements[] = $this->settings->getCliFramework();
     }
 

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -26,6 +26,19 @@ class Defaults
     public $phpVersions = ['5.4', '5.5', '5.6', '7.0', '7.1'];
 
     /**
+     * Available php files to test on appveyor.
+     *
+     * @var array
+     */
+    public $phpAppVeyorVersions = [
+        '5.4' => 'php-5.4.45-nts-Win32-VC9-x86.zip',
+        '5.5' => 'php-5.5.37-nts-Win32-VC11-x86.zip',
+        '5.6' => 'php-5.6.29-nts-Win32-VC11-x86.zip',
+        '7.0' => 'php-7.0.17-nts-Win32-VC14-x86.zip',
+        '7.1' => 'php-7.1.3-nts-Win32-VC14-x64.zip',
+    ];
+
+    /**
      * Php versions without a semver scheme.
      *
      * @var array

--- a/src/Helpers/Str.php
+++ b/src/Helpers/Str.php
@@ -171,6 +171,19 @@ class Str
     }
 
     /**
+     * Returns the minor version of the given version.
+     *
+     * @param  string $version
+     * @return string
+     */
+    public function toMinorVersion($version)
+    {
+        list($major, $minor) = explode('.', $version);
+
+        return $major . '.' . $minor;
+    }
+
+    /**
      * Validate php version string
      *
      * @param string $version

--- a/src/Helpers/Travis.php
+++ b/src/Helpers/Travis.php
@@ -7,16 +7,15 @@ use JonathanTorres\Construct\Defaults;
 class Travis
 {
     /**
-     * Returns the minor version of the given version.
+     * String helper.
      *
-     * @param  string $version
-     * @return string
+     * @var \JonathanTorres\Construct\Helpers\Str
      */
-    private function toMinorVersion($version)
-    {
-        list($major, $minor) = explode('.', $version);
+    private $stringHelper;
 
-        return $major . '.' . $minor;
+    public function __construct()
+    {
+        $this->stringHelper = new Str();
     }
 
     /**
@@ -33,8 +32,8 @@ class Travis
 
         $phpVersionsToTest = array_filter($supportedPhpVersions, function ($supportedPhpVersion) use ($projectPhpVersion) {
             return version_compare(
-                $this->toMinorversion($projectPhpVersion),
-                $this->toMinorversion($supportedPhpVersion),
+                $this->stringHelper->toMinorversion($projectPhpVersion),
+                $this->stringHelper->toMinorversion($supportedPhpVersion),
                 '<='
             ) === true;
         });
@@ -59,7 +58,7 @@ class Travis
         for ($i = 0; $i < count($phpVersions); $i++) {
             $phpVersion = $phpVersions[$i];
             if (!in_array($phpVersions[$i], $nonSemverVersions)) {
-                $phpVersion = $this->toMinorVersion($phpVersions[$i]);
+                $phpVersion = $this->stringHelper->toMinorVersion($phpVersions[$i]);
             }
 
             if (count($i) !== 0) {

--- a/src/stubs/appveyor.stub
+++ b/src/stubs/appveyor.stub
@@ -1,0 +1,39 @@
+build: false
+clone_depth: 1
+platform: x86
+
+environment:
+    matrix:
+        - PHP_DOWNLOAD_FILE: {php_download_file}
+
+cache:
+    - c:\php -> .appveyor.yml
+    - '%LOCALAPPDATA%\Composer'
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+    - git config --global core.autocrlf input
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
+    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - copy php.ini-production php.ini /Y
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - composer update --no-progress --ansi
+
+test_script:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - composer test

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -351,7 +351,7 @@ class ConstructCommandTest extends PHPUnit
 
     public function testProjectGenerationWithCli()
     {
-        $this->setMocks(4, 2, 1);
+        $this->setMocks(4, 2, 1, 12, 13);
         $this->filesystem->shouldReceive('put')->times(0);
 
         $app = $this->setApplication();

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -818,8 +818,22 @@ class ConstructTest extends PHPUnit
 
         $this->construct->generate($settings, $this->gitHelper, $this->scriptHelper);
 
-        $this->assertSame($this->getStub('with-cli/composer'), $this->getFile('composer.json'));
-        $this->assertSame($this->getStub('with-cli/cli-script'), $this->getFile('bin/cli-script'));
+        $this->assertSame(
+            $this->getStub('with-cli/composer'),
+            $this->getFile('composer.json')
+        );
+        $this->assertSame(
+            $this->getStub('with-cli/cli-script'),
+            $this->getFile('bin/cli-script')
+        );
+        $this->assertSame(
+            $this->getStub('with-cli/appveyor'),
+            $this->getFile('.appveyor.yml')
+        );
+        $this->assertSame(
+            $this->getStub('with-cli/gitattributes'),
+            $this->getFile('.gitattributes')
+        );
     }
 
     /**

--- a/tests/Helpers/StrTest.php
+++ b/tests/Helpers/StrTest.php
@@ -151,4 +151,23 @@ class StrTest extends PHPUnit
             'keyword_null' => [null, ""],
         ];
     }
+
+    /**
+     * @dataProvider versionProvider
+     */
+    public function testReturnsExpectedMinorVersion($expected, $version)
+    {
+        $this->assertEquals($expected, $this->str->toMinorVersion($version));
+    }
+
+    /**
+     * @return array
+     */
+    public function versionProvider()
+    {
+        return [
+            '5.6.1' => ['5.6', '5.6.1'],
+            '7.1.17' => ['7.1', '7.1.17'],
+        ];
+    }
 }

--- a/tests/stubs/with-cli/appveyor.stub
+++ b/tests/stubs/with-cli/appveyor.stub
@@ -1,0 +1,39 @@
+build: false
+clone_depth: 1
+platform: x86
+
+environment:
+    matrix:
+        - PHP_DOWNLOAD_FILE: php-5.6.29-nts-Win32-VC11-x86.zip
+
+cache:
+    - c:\php -> .appveyor.yml
+    - '%LOCALAPPDATA%\Composer'
+
+init:
+    - SET PATH=c:\php;%PATH%
+    - SET COMPOSER_NO_INTERACTION=1
+    - SET PHP=1
+    - SET ANSICON=121x90 (121x90)
+    - git config --global core.autocrlf input
+
+install:
+    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
+    - cd c:\php
+    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
+    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor DownloadFile https://getcomposer.org/composer.phar
+    - copy php.ini-production php.ini /Y
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - composer update --no-progress --ansi
+
+test_script:
+    - cd %APPVEYOR_BUILD_FOLDER%
+    - composer test

--- a/tests/stubs/with-cli/gitattributes.stub
+++ b/tests/stubs/with-cli/gitattributes.stub
@@ -1,0 +1,13 @@
+* text=auto eol=lf
+
+.appveyor.yml export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.gitmessage export-ignore
+.travis.yml export-ignore
+CHANGELOG.md export-ignore
+CONTRIBUTING.md export-ignore
+LICENSE.md export-ignore
+README.md export-ignore
+phpunit.xml.dist export-ignore
+tests/ export-ignore


### PR DESCRIPTION
An initial AppVeyor configuration is generated for CLI applications.

This currently just configures __one__ PHP version to integrate against; might be extended to a full set.