### PR TITLE
Enable PDS compliance.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
     - Utilise PHPUnit's forward compatibility layer for PHPUnit 6. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#179](https://github.com/jonathantorres/construct/issues/179).
     - The email notification for successful Travis CI builds has been disabled. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#198](https://github.com/jonathantorres/construct/issues/198).
     - The generated change log has been aligned with the [Keep a Changelog](http://keepachangelog.com/) format. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#202](https://github.com/jonathantorres/construct/issues/202).
+    - The CLI binary has been moved to `bin` to achieve [PDS](http://php-pds.com) compliance. Done by [@raphaelstolt](https://github.com/raphaelstolt).
 
 #### v1.14.1 `2017-04-07`
 - `Added`

--- a/bin/construct
+++ b/bin/construct
@@ -2,6 +2,7 @@
 
 <?php
 
+$autoloaded = false;
 $autoloads = [
     __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
@@ -10,8 +11,15 @@ $autoloads = [
 foreach ($autoloads as $autoload) {
     if (file_exists($autoload)) {
         require $autoload;
+        $autoloaded = true;
         break;
     }
+}
+
+if (false === $autoloaded) {
+   echo('You need to set up the project dependencies by running the following command:' . PHP_EOL .
+       '> composer install' . PHP_EOL);
+   exit(1);
 }
 
 use JonathanTorres\Construct\Commands\ConstructCommand;

--- a/bin/construct
+++ b/bin/construct
@@ -2,10 +2,16 @@
 
 <?php
 
-if (file_exists(__DIR__ . '/../../autoload.php')) {
-    require __DIR__ . '/../../autoload.php';
-} else {
-    require __DIR__ . '/vendor/autoload.php';
+$autoloads = [
+    __DIR__ . '/../../../autoload.php',
+    __DIR__ . '/../vendor/autoload.php',
+];
+
+foreach ($autoloads as $autoload) {
+    if (file_exists($autoload)) {
+        require $autoload;
+        break;
+    }
 }
 
 use JonathanTorres\Construct\Commands\ConstructCommand;

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         },
         "sort-packages": true
     },
-    "bin": ["construct"],
+    "bin": ["bin/construct"],
     "scripts": {
         "test": "phpunit",
         "cs-fix": "php-cs-fixer fix . -vv || true",

--- a/src/stubs/cli-script.stub
+++ b/src/stubs/cli-script.stub
@@ -5,7 +5,6 @@
 $autoloads = [
     __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/vendor/autoload.php',
 ];
 
 foreach ($autoloads as $autoload) {

--- a/src/stubs/cli-script.stub
+++ b/src/stubs/cli-script.stub
@@ -2,6 +2,7 @@
 
 <?php
 
+$autoloaded = false;
 $autoloads = [
     __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
@@ -10,6 +11,13 @@ $autoloads = [
 foreach ($autoloads as $autoload) {
     if (file_exists($autoload)) {
         require $autoload;
+        $autoloaded = true;
         break;
     }
+}
+
+if (false === $autoloaded) {
+   echo('You need to set up the project dependencies by running the following command:' . PHP_EOL .
+       '> composer install' . PHP_EOL);
+   exit(1);
 }

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -475,7 +475,7 @@ CONTENT;
      */
     public function testExecutable()
     {
-        $constructCommand = 'php construct --no-ansi';
+        $constructCommand = 'php bin/construct --no-ansi';
         exec($constructCommand, $output, $returnValue);
 
         $this->assertStringStartsWith(

--- a/tests/stubs/with-cli/cli-script.stub
+++ b/tests/stubs/with-cli/cli-script.stub
@@ -2,15 +2,22 @@
 
 <?php
 
+$autoloaded = false;
 $autoloads = [
     __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
-    __DIR__ . '/vendor/autoload.php',
 ];
 
 foreach ($autoloads as $autoload) {
     if (file_exists($autoload)) {
         require $autoload;
+        $autoloaded = true;
         break;
     }
+}
+
+if (false === $autoloaded) {
+   echo('You need to set up the project dependencies by running the following command:' . PHP_EOL .
+       '> composer install' . PHP_EOL);
+   exit(1);
 }


### PR DESCRIPTION
Construct is now [PDS](http://php-pds.com/) compliant. While at it I also added a guard for missing project dependencies.