### PR TITLE
Change log format alignment. Fixes #202.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - The Xdebug extension disabling has been removed from the Travis CI configuration as Composer takes care of this since 1.3. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#194](https://github.com/jonathantorres/construct/issues/194).
     - Utilise PHPUnit's forward compatibility layer for PHPUnit 6. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#179](https://github.com/jonathantorres/construct/issues/179).
     - The email notification for successful Travis CI builds has been disabled. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#198](https://github.com/jonathantorres/construct/issues/198).
+    - The generated change log has been aligned with the [Keep a Changelog](http://keepachangelog.com/) format. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#202](https://github.com/jonathantorres/construct/issues/202).
 
 #### v1.14.1 `2017-04-07`
 - `Added`

--- a/src/stubs/CHANGELOG.stub
+++ b/src/stubs/CHANGELOG.stub
@@ -1,4 +1,7 @@
-# Changelog
+# Change Log
+All notable changes to this project will be documented in this file.
 
-#### vMAJOR.MINOR.PATCH `{creation_date}`
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## vMAJOR.MINOR.PATCH - {creation_date}
 - First release.

--- a/tests/stubs/CHANGELOG.stub
+++ b/tests/stubs/CHANGELOG.stub
@@ -1,4 +1,7 @@
-# Changelog
+# Change Log
+All notable changes to this project will be documented in this file.
 
-#### vMAJOR.MINOR.PATCH `{creation_date}`
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## vMAJOR.MINOR.PATCH - {creation_date}
 - First release.


### PR DESCRIPTION
Aligned the generated change log with the [Keep a Changelog](http://keepachangelog.com/) format.

Should also be applied to the project it's change log sometime.