### PR TITLE
Add PHP 7.2 into the mix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,24 +4,28 @@ platform: x86
 
 environment:
     matrix:
-        - PHP_DOWNLOAD_FILE: php-5.6.29-nts-Win32-VC11-x86.zip
+        - php_ver_target: 7.2
 
 cache:
-    - c:\php -> .appveyor.yml
+    - C:\php -> .appveyor.yml
+    - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+    - C:\ProgramData\chocolatey\lib -> .appveyor.yml
     - '%LOCALAPPDATA%\Composer'
 
 init:
-    - SET PATH=c:\php;%PATH%
+    - SET PATH=C:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET PHP=1
     - SET ANSICON=121x90 (121x90)
     - git config --global core.autocrlf input
 
 install:
-    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
-    - cd c:\php
-    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
-    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+    - IF EXIST C:\php (SET PHP=0) ELSE (mkdir C:\php)
+    - cd C:\php
+    # Enable Windows update service
+    - ps: Set-Service wuauserv -StartupType Manual
+      # Install PHP
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor DownloadFile https://getcomposer.org/composer.phar
     - copy php.ini-production php.ini /Y

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
     - php: 5.6
   fast_finish: true
   allow_failures:
+    - php: 7.2
     - php: nightly
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   include:
     - php: hhvm
     - php: nightly
+    - php: 7.2
     - php: 7.1
     - php: 7.0
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 #### v1.16.0 `2017-??-??`
+- `Added`
+    - Added PHP version 7.2 to the available versions. Done by [@raphaelstolt](https://github.com/raphaelstolt).
 - `Fixed`
     - Removed EOL PHP versions (i.e. `5.4` and `5.5`). Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#211](https://github.com/jonathantorres/construct/issues/211).
     - Added a guard to check if the project directory to be already exists. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#212](https://github.com/jonathantorres/construct/issues/212).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Fixed`
     - Removed EOL PHP versions (i.e. `5.4` and `5.5`). Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#211](https://github.com/jonathantorres/construct/issues/211).
     - Added a guard to check if the project directory to be already exists. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#212](https://github.com/jonathantorres/construct/issues/212).
+    - Generated AppVeyor configuration uses minor versions instead of ZIP archives. Done by [@raphaelstolt](https://github.com/raphaelstolt).
 
 #### v1.15.2 `2017-09-18`
 - `Fixed`

--- a/src/Constructors/Cli.php
+++ b/src/Constructors/Cli.php
@@ -2,8 +2,6 @@
 
 namespace Construct\Constructors;
 
-use Construct\Defaults;
-
 class Cli extends Constructor implements ConstructorContract
 {
     /**
@@ -25,10 +23,8 @@ class Cli extends Constructor implements ConstructorContract
             );
 
             $minorPhpVersion = $this->str->toMinorVersion($this->settings->getPhpVersion());
-            $appveyorVersions = (new Defaults())->getPhpAppVeyorVersions();
-            $phpDownloadFile = $appveyorVersions[$minorPhpVersion];
 
-            $content = str_replace('{php_download_file}', $phpDownloadFile, $appveyorConfiguration);
+            $content = str_replace('{php_version}', $minorPhpVersion, $appveyorConfiguration);
             $this->filesystem->put($this->settings->getProjectLower() . '/' . '.appveyor.yml', $content);
             $this->gitAttributes->addExportIgnore('.appveyor.yml');
             $this->composer->addRequirement($this->settings->getCliFramework());

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -23,7 +23,7 @@ class Defaults
      *
      * @var array
      */
-    private $phpVersions = ['5.6', '7.0', '7.1'];
+    private $phpVersions = ['5.6', '7.0', '7.1', '7.2'];
 
     /**
      * Available php files to test on appveyor.
@@ -34,6 +34,7 @@ class Defaults
         '5.6' => 'php-5.6.29-nts-Win32-VC11-x86.zip',
         '7.0' => 'php-7.0.17-nts-Win32-VC14-x86.zip',
         '7.1' => 'php-7.1.3-nts-Win32-VC14-x64.zip',
+        '7.2' => 'php-7.2.0-nts-Win32-VC14-x64.zip',
     ];
 
     /**

--- a/src/Defaults.php
+++ b/src/Defaults.php
@@ -26,18 +26,6 @@ class Defaults
     private $phpVersions = ['5.6', '7.0', '7.1', '7.2'];
 
     /**
-     * Available php files to test on appveyor.
-     *
-     * @var array
-     */
-    private $phpAppVeyorVersions = [
-        '5.6' => 'php-5.6.29-nts-Win32-VC11-x86.zip',
-        '7.0' => 'php-7.0.17-nts-Win32-VC14-x86.zip',
-        '7.1' => 'php-7.1.3-nts-Win32-VC14-x64.zip',
-        '7.2' => 'php-7.2.0-nts-Win32-VC14-x64.zip',
-    ];
-
-    /**
      * Php versions without a semver scheme.
      *
      * @var array
@@ -124,16 +112,6 @@ class Defaults
     public function getPhpVersions()
     {
         return $this->phpVersions;
-    }
-
-    /**
-     * Get the available php versions to test on AppVeyor.
-     *
-     * @return array
-     */
-    public function getPhpAppVeyorVersions()
-    {
-        return $this->phpAppVeyorVersions;
     }
 
     /**

--- a/src/Helpers/Travis.php
+++ b/src/Helpers/Travis.php
@@ -67,7 +67,7 @@ class Travis
                 $phpVersion = $this->str->toMinorVersion($phpVersions[$i]);
             }
 
-            if (count($i) !== 0) {
+            if ($i >= 0) {
                 $runOn .= '    ';
             }
 

--- a/src/stubs/appveyor.stub
+++ b/src/stubs/appveyor.stub
@@ -4,24 +4,28 @@ platform: x86
 
 environment:
     matrix:
-        - PHP_DOWNLOAD_FILE: {php_download_file}
+        - php_ver_target: {php_version}
 
 cache:
-    - c:\php -> .appveyor.yml
+    - C:\php -> .appveyor.yml
+    - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+    - C:\ProgramData\chocolatey\lib -> .appveyor.yml
     - '%LOCALAPPDATA%\Composer'
 
 init:
-    - SET PATH=c:\php;%PATH%
+    - SET PATH=C:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET PHP=1
     - SET ANSICON=121x90 (121x90)
     - git config --global core.autocrlf input
 
 install:
-    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
-    - cd c:\php
-    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
-    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+    - IF EXIST C:\php (SET PHP=0) ELSE (mkdir C:\php)
+    - cd C:\php
+    # Enable Windows update service
+    - ps: Set-Service wuauserv -StartupType Manual
+      # Install PHP
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor DownloadFile https://getcomposer.org/composer.phar
     - copy php.ini-production php.ini /Y

--- a/tests/ConstructTest.php
+++ b/tests/ConstructTest.php
@@ -474,6 +474,28 @@ class ConstructTest extends TestCase
         $this->assertSame($this->getStub('travis.php71'), $this->getFile('.travis.yml'));
     }
 
+    public function test_project_generation_with_php72()
+    {
+        $settings = $this->container->get('Construct\Settings');
+        $settings->setProjectName('jonathantorres/logger');
+        $settings->setTestingFramework('phpunit');
+        $settings->setLicense('MIT');
+        $settings->setNamespace('Vendor\Project');
+        $settings->setPhpVersion('7.2.0');
+        $settings->setGithubTemplates(false);
+        $settings->setCodeOfConduct(false);
+        $settings->setGithubDocs(false);
+        $settings->setCliFramework(null);
+
+        $this->construct = new Construct($this->container);
+        $this->setConstructors();
+        $this->setScriptHelperComposerInstallExpectationWithPackages();
+
+        $this->construct->generate();
+        $this->assertSame($this->getStub('composer.php72'), $this->getFile('composer.json'));
+        $this->assertSame($this->getStub('travis.php72'), $this->getFile('.travis.yml'));
+    }
+
     /**
      * @ticket 170 (https://github.com/jonathantorres/construct/issues/170)
      */

--- a/tests/Helpers/TravisTest.php
+++ b/tests/Helpers/TravisTest.php
@@ -26,6 +26,7 @@ class TravisTest extends TestCase
             '5.6',
             '7.0',
             '7.1',
+            '7.2',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -41,6 +42,7 @@ class TravisTest extends TestCase
             '5.6',
             '7.0',
             '7.1',
+            '7.2',
         ]);
 
         $stringExpected = <<<CONTENT
@@ -48,6 +50,7 @@ class TravisTest extends TestCase
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
 CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
@@ -63,6 +66,7 @@ CONTENT;
             '5.6',
             '7.0',
             '7.1',
+            '7.2',
         ], true);
 
         $stringExpected = <<<CONTENT
@@ -70,6 +74,7 @@ CONTENT;
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
       env:
       - LINT=true
 CONTENT;
@@ -90,6 +95,7 @@ CONTENT;
             '5.6',
             '7.0',
             '7.1',
+            '7.2',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -106,6 +112,7 @@ CONTENT;
             'nightly',
             '7.0',
             '7.1',
+            '7.2',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -120,12 +127,14 @@ CONTENT;
             'hhvm',
             '7.0',
             '7.1',
+            '7.2',
         ]);
 
         $stringExpected = <<<CONTENT
     - php: hhvm
     - php: 7.0
     - php: 7.1
+    - php: 7.2
 CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
@@ -141,6 +150,7 @@ CONTENT;
             'hhvm',
             'nightly',
             '7.1',
+            '7.2',
         ];
 
         $this->assertEquals($versionsToTest, $versionsExpected);
@@ -154,11 +164,31 @@ CONTENT;
         $versionsToRun = $this->travis->phpVersionsToRun([
             'hhvm',
             '7.1',
+            '7.2',
         ]);
 
         $stringExpected = <<<CONTENT
     - php: hhvm
     - php: 7.1
+    - php: 7.2
+CONTENT;
+
+        $this->assertEquals($versionsToRun, $stringExpected);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_string_of_all_versions_to_run_on_a_php7_2_project()
+    {
+        $versionsToRun = $this->travis->phpVersionsToRun([
+            'hhvm',
+            '7.2',
+        ]);
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+    - php: 7.2
 CONTENT;
 
         $this->assertEquals($versionsToRun, $stringExpected);
@@ -172,11 +202,33 @@ CONTENT;
         $versionsToRun = $this->travis->phpVersionsToRun([
             'hhvm',
             '7.1',
+            '7.2',
         ], true);
 
         $stringExpected = <<<CONTENT
     - php: hhvm
     - php: 7.1
+    - php: 7.2
+      env:
+      - LINT=true
+CONTENT;
+
+        $this->assertEquals($versionsToRun, $stringExpected);
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_generate_string_of_all_versions_to_run_on_a_php7_2_project_with_lint_env()
+    {
+        $versionsToRun = $this->travis->phpVersionsToRun([
+            'hhvm',
+            '7.2',
+        ], true);
+
+        $stringExpected = <<<CONTENT
+    - php: hhvm
+    - php: 7.2
       env:
       - LINT=true
 CONTENT;

--- a/tests/stubs/composer.php72.stub
+++ b/tests/stubs/composer.php72.stub
@@ -1,0 +1,33 @@
+{
+    "name": "jonathantorres/logger",
+    "description": "PHP project.",
+    "keywords": [],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jonathan Torres",
+            "email": "jonathantorres41@gmail.com"
+        }
+    ],
+    "require": {
+        "php": ">=7.2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Jonathantorres\\Logger\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Jonathantorres\\Logger\\Tests\\": "tests/"
+        }
+    },
+    "minimum-stability": "stable",
+    "config": {
+        "sort-packages": true
+    },
+    "scripts": {
+        "test": "phpunit",
+        "configure-commit-template": "git config --add commit.template .gitmessage"
+    }
+}

--- a/tests/stubs/travis.php7.stub
+++ b/tests/stubs/travis.php7.stub
@@ -13,6 +13,7 @@ matrix:
     - php: nightly
     - php: 7.0
     - php: 7.1
+    - php: 7.2
   fast_finish: true
 
 cache:

--- a/tests/stubs/travis.php71.stub
+++ b/tests/stubs/travis.php71.stub
@@ -12,6 +12,7 @@ matrix:
     - php: hhvm
     - php: nightly
     - php: 7.1
+    - php: 7.2
   fast_finish: true
 
 cache:

--- a/tests/stubs/travis.php72.stub
+++ b/tests/stubs/travis.php72.stub
@@ -11,9 +11,6 @@ matrix:
   include:
     - php: hhvm
     - php: nightly
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
     - php: 7.2
   fast_finish: true
 

--- a/tests/stubs/travis.stub
+++ b/tests/stubs/travis.stub
@@ -14,6 +14,7 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
   fast_finish: true
 
 cache:

--- a/tests/stubs/with-cli/appveyor.stub
+++ b/tests/stubs/with-cli/appveyor.stub
@@ -4,24 +4,28 @@ platform: x86
 
 environment:
     matrix:
-        - PHP_DOWNLOAD_FILE: php-5.6.29-nts-Win32-VC11-x86.zip
+        - php_ver_target: 5.6
 
 cache:
-    - c:\php -> .appveyor.yml
+    - C:\php -> .appveyor.yml
+    - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+    - C:\ProgramData\chocolatey\lib -> .appveyor.yml
     - '%LOCALAPPDATA%\Composer'
 
 init:
-    - SET PATH=c:\php;%PATH%
+    - SET PATH=C:\php;%PATH%
     - SET COMPOSER_NO_INTERACTION=1
     - SET PHP=1
     - SET ANSICON=121x90 (121x90)
     - git config --global core.autocrlf input
 
 install:
-    - IF EXIST c:\php (SET PHP=0) ELSE (mkdir c:\php)
-    - cd c:\php
-    - IF %PHP%==1 appveyor DownloadFile http://windows.php.net/downloads/releases/archives/%PHP_DOWNLOAD_FILE%
-    - IF %PHP%==1 7z x %PHP_DOWNLOAD_FILE% -y > 7z.log
+    - IF EXIST C:\php (SET PHP=0) ELSE (mkdir C:\php)
+    - cd C:\php
+    # Enable Windows update service
+    - ps: Set-Service wuauserv -StartupType Manual
+      # Install PHP
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - appveyor DownloadFile https://getcomposer.org/composer.phar
     - copy php.ini-production php.ini /Y

--- a/tests/stubs/with-phpcs/travis.stub
+++ b/tests/stubs/with-phpcs/travis.stub
@@ -14,6 +14,7 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
       env:
       - LINT=true
   fast_finish: true


### PR DESCRIPTION
Added PHP 7.2 support and also eased the AppVeyor configuration. Both for the generated configuration files as well for the own repository configurations.