### PR TITLE
Avoid constructing into existing project directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### v1.16.0 `2017-??-??`
 - `Fixed`
     - Removed EOL PHP versions (i.e. `5.4` and `5.5`). Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#211](https://github.com/jonathantorres/construct/issues/211).
+    - Added a guard to check if the project directory to be already exists. Done by [@raphaelstolt](https://github.com/raphaelstolt). See [#212](https://github.com/jonathantorres/construct/issues/212).
 
 #### v1.15.2 `2017-09-18`
 - `Fixed`

--- a/src/Commands/ConstructCommand.php
+++ b/src/Commands/ConstructCommand.php
@@ -3,6 +3,7 @@
 namespace Construct\Commands;
 
 use Construct\Construct;
+use Construct\Exceptions\ProjectDirectoryToBeAlreadyExists;
 use Construct\Constructors\Cli;
 use Construct\Constructors\CodeOfConduct;
 use Construct\Constructors\Composer;
@@ -258,7 +259,16 @@ class ConstructCommand extends Command
         $this->construct->addConstructor(new GitMessage($this->construct->getContainer()));
         $this->construct->addConstructor(new GitAttributes($this->construct->getContainer()));
 
-        $this->construct->generate();
+        try {
+            $this->construct->generate();
+        } catch (ProjectDirectoryToBeAlreadyExists $e) {
+            $warningMessage = '<error>Warning: "' . $projectName . '" would be '
+                . 'constructed into existing directory "' . $this->settings->getProjectLower() . '". '
+                . 'Aborting further construction.</error>';
+            $output->writeln($warningMessage);
+
+            return false;
+        }
 
         $this->initializedGitMessage($output);
         $this->bootstrappedCodeceptionMessage($output);

--- a/src/Commands/InteractiveCommand.php
+++ b/src/Commands/InteractiveCommand.php
@@ -4,6 +4,7 @@ namespace Construct\Commands;
 
 use Construct\Construct;
 use RuntimeException;
+use Construct\Exceptions\ProjectDirectoryToBeAlreadyExists;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -180,7 +181,18 @@ class InteractiveCommand extends Command
         $this->settings->setCliFramework($cliFramework);
 
         $output->writeln('Creating your project...');
-        $this->construct->generate();
+
+        try {
+            $this->construct->generate();
+        } catch (ProjectDirectoryToBeAlreadyExists $e) {
+            $warningMessage = '<error>Warning: "' . $projectName . '" would be '
+                . 'constructed into existing directory "' . $this->settings->getProjectLower() . '". '
+                . 'Aborting further construction.</error>';
+            $output->writeln($warningMessage);
+
+            return false;
+        }
+
         $output->writeln('<info>Project "' . $projectName . '" constructed.</info>');
     }
 }

--- a/src/Construct.php
+++ b/src/Construct.php
@@ -52,6 +52,7 @@ class Construct
     /**
      * Generates the project using the specified constructors.
      *
+     * @throws ProjectDirectoryToBeAlreadyExists
      * @return void
      */
     public function generate()

--- a/src/Constructors/Src.php
+++ b/src/Constructors/Src.php
@@ -2,6 +2,8 @@
 
 namespace Construct\Constructors;
 
+use Construct\Exceptions\ProjectDirectoryToBeAlreadyExists;
+
 class Src extends Constructor implements ConstructorContract
 {
     /**
@@ -12,13 +14,29 @@ class Src extends Constructor implements ConstructorContract
     private $srcPath = 'src';
 
     /**
+     * Checks whether the project directory to be already exist.
+     *
+     * @return boolean
+     */
+    private function projectDirectoryExists()
+    {
+        return $this->filesystem->isDirectory(
+            $this->settings->getProjectLower()
+        );
+    }
+
+    /**
      * This constructor creates the project's root folder
      * and the src folder inside of it.
      *
+     * @throws ProjectDirectoryToBeAlreadyExists
      * @return void
      */
     public function run()
     {
+        if ($this->projectDirectoryExists()) {
+            throw new ProjectDirectoryToBeAlreadyExists();
+        }
         $this->filesystem->makeDirectory($this->settings->getProjectLower());
         $this->filesystem->makeDirectory($this->settings->getProjectLower() . '/' . $this->srcPath);
     }

--- a/src/Exceptions/ProjectDirectoryToBeAlreadyExists.php
+++ b/src/Exceptions/ProjectDirectoryToBeAlreadyExists.php
@@ -1,0 +1,6 @@
+<?php
+namespace  Construct\Exceptions;
+
+class ProjectDirectoryToBeAlreadyExists extends \Exception
+{
+}

--- a/tests/Commands/ConstructCommandTest.php
+++ b/tests/Commands/ConstructCommandTest.php
@@ -33,7 +33,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2, 0, 11);
+        $this->setMocks(3, 3, 0, 11);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -65,7 +65,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -83,7 +83,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -104,7 +104,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -125,7 +125,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(2, 2, 0, 9, 10);
+        $this->setMocks(2, 3, 0, 9, 10);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -144,7 +144,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(2, 2, 0, 9, 10);
+        $this->setMocks(2, 3, 0, 9, 10);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -163,7 +163,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -190,7 +190,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -210,7 +210,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -228,7 +228,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -246,7 +246,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 3);
+        $this->setMocks(3, 4);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -265,7 +265,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2, 1);
+        $this->setMocks(3, 3, 1);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -283,7 +283,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2);
+        $this->setMocks(3, 3);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -301,7 +301,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2, 1);
+        $this->setMocks(3, 3, 1);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -319,7 +319,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2, 1);
+        $this->setMocks(3, 3, 1);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -333,11 +333,31 @@ class ConstructCommandTest extends TestCase
         $this->assertSame('Project "vendor/project" constructed.' . PHP_EOL, $commandTester->getDisplay());
     }
 
+    /**
+     * @ticket 212 (https://github.com/jonathantorres/construct/issues/212)
+     */
+    public function test_project_generation_with_existing_directory()
+    {
+        $this->filesystem->shouldReceive('getDefaultConfigurationFile');
+        $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
+        $this->filesystem->shouldReceive('isDirectory')->times(1)->andReturn(true);
+
+        $app = $this->setApplication();
+        $command = $app->find('generate');
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(['command' => $command->getName(), 'name' => 'vendor/project']);
+
+        $output = 'Warning: "vendor/project" would be constructed into existing directory "project". '
+            . 'Aborting further construction.' . PHP_EOL;
+
+        $this->assertSame($output, $commandTester->getDisplay());
+    }
+
     public function test_project_generation_with_environment_files()
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(3, 2, 2);
+        $this->setMocks(3, 3, 2);
 
         $app = $this->setApplication();
         $command = $app->find('generate');
@@ -355,7 +375,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(4, 2, 0, 13, 14);
+        $this->setMocks(4, 3, 0, 13, 14);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -374,7 +394,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(4, 2);
+        $this->setMocks(4, 3);
         $this->filesystem->shouldReceive('put')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -393,7 +413,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(4, 2, 1, 12, 13);
+        $this->setMocks(4, 3, 1, 12, 13);
         $this->filesystem->shouldReceive('put')->times(0);
 
         $app = $this->setApplication();
@@ -412,7 +432,7 @@ class ConstructCommandTest extends TestCase
     {
         $this->filesystem->shouldReceive('getDefaultConfigurationFile');
         $this->filesystem->shouldReceive('hasDefaultConfigurationFile');
-        $this->setMocks(4, 2, 1, 12, 13);
+        $this->setMocks(4, 3, 1, 12, 13);
         $this->filesystem->shouldReceive('put')->times(0);
 
         $app = $this->setApplication();
@@ -439,7 +459,7 @@ class ConstructCommandTest extends TestCase
         $this->filesystem->shouldReceive('isFile')->andReturn(true);
         $this->filesystem->shouldReceive('isReadable')->andReturn(true);
         $this->filesystem->shouldReceive('get')->with($configuration)->andReturn(file_get_contents($configuration));
-        $this->setMocks(5, 3, 8, 12, 14);
+        $this->setMocks(5, 4, 8, 12, 14);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -469,7 +489,7 @@ class ConstructCommandTest extends TestCase
         $this->filesystem->shouldReceive('isFile')->andReturn(true);
         $this->filesystem->shouldReceive('isReadable')->andReturn(true);
         $this->filesystem->shouldReceive('get')->with($configuration)->andReturn(file_get_contents($configuration));
-        $this->setMocks(5, 3, 8, 12, 14);
+        $this->setMocks(5, 4, 8, 12, 14);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();
@@ -502,7 +522,7 @@ class ConstructCommandTest extends TestCase
         $this->filesystem->shouldReceive('isFile')->andReturn(true);
         $this->filesystem->shouldReceive('isReadable')->andReturn(true);
         $this->filesystem->shouldReceive('get')->with($configuration)->andReturn(file_get_contents($configuration));
-        $this->setMocks(4, 3, 8, 13, 14);
+        $this->setMocks(4, 4, 8, 13, 14);
         $this->filesystem->shouldReceive('move')->times(1)->andReturnNull();
 
         $app = $this->setApplication();


### PR DESCRIPTION
Fix for #212.

In the `InteractiveCommand` the exists directory check should prolly already be done in the `projectNameQuestion` validator to abort as early as possible. This might require visibility changes of `Construct\Construct->saveProjectNames` and `Construct\Constructors\Src->projectDirectoryExists`.